### PR TITLE
fix prefixItems to accept boolean schemas

### DIFF
--- a/builder_gen.go
+++ b/builder_gen.go
@@ -59,7 +59,7 @@ type Builder struct {
 	oneOf                 []SchemaOrBool
 	pattern               *string
 	patternProperties     []*propPair
-	prefixItems           []*Schema
+	prefixItems           []SchemaOrBool
 	properties            []*propPair
 	propertyNames         *Schema
 	reference             *string
@@ -480,9 +480,16 @@ func (b *Builder) PatternProperty(n string, v *Schema) *Builder {
 	return b
 }
 
-func (b *Builder) PrefixItems(v ...*Schema) *Builder {
+func (b *Builder) PrefixItems(v ...SchemaOrBool) *Builder {
 	if b.err != nil {
 		return b
+	}
+
+	for _, item := range v {
+		if err := validateSchemaOrBool(item); err != nil {
+			b.err = fmt.Errorf(`invalid value in PrefixItems: %w`, err)
+			return b
+		}
 	}
 
 	b.prefixItems = v

--- a/internal/cmd/genobjects/objects.yml
+++ b/internal/cmd/genobjects/objects.yml
@@ -47,7 +47,7 @@ objects:
         json: 'else'
         type: 'SchemaOrBool'
       - name: prefixItems
-        type: '[]*Schema'
+        type: '[]SchemaOrBool'
       - name: items
         type: 'SchemaOrBool'
       - name: additionalItems

--- a/schema_gen.go
+++ b/schema_gen.go
@@ -112,7 +112,7 @@ type Schema struct {
 	oneOf                 []SchemaOrBool
 	pattern               *string
 	patternProperties     map[string]*Schema
-	prefixItems           []*Schema
+	prefixItems           []SchemaOrBool
 	properties            map[string]*Schema
 	propertyNames         *Schema
 	reference             *string
@@ -466,7 +466,7 @@ func (s *Schema) HasPrefixItems() bool {
 	return s.populatedFields&PrefixItemsField != 0
 }
 
-func (s *Schema) PrefixItems() []*Schema {
+func (s *Schema) PrefixItems() []SchemaOrBool {
 	return s.prefixItems
 }
 
@@ -1227,9 +1227,9 @@ LOOP:
 				s.patternProperties = v
 				s.populatedFields |= PatternPropertiesField
 			case keywords.PrefixItems:
-				var v []*Schema
-				if err := dec.Decode(&v); err != nil {
-					return fmt.Errorf(`json-schema: failed to decode value for field "prefixItems" (attempting to unmarshal as []*Schema): %w`, err)
+				v, err := unmarshalSchemaOrBoolSlice(dec)
+				if err != nil {
+					return fmt.Errorf(`json-schema: failed to decode value for field "prefixItems" (attempting to unmarshal as []SchemaOrBool slice): %w`, err)
 				}
 				s.prefixItems = v
 				s.populatedFields |= PrefixItemsField

--- a/schema_prefixitems_test.go
+++ b/schema_prefixitems_test.go
@@ -1,0 +1,40 @@
+package schema_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrefixItemsBooleanSchema guards against a regression where prefixItems
+// elements were typed as *Schema and could not represent boolean schemas
+// (true/false), even though JSON Schema 2020-12 allows any schema — including a
+// boolean — as a prefixItems element.
+func TestPrefixItemsBooleanSchema(t *testing.T) {
+	const src = `{
+		"prefixItems": [true, {"const": "bar"}, false]
+	}`
+
+	var s schema.Schema
+	require.NoError(t, json.Unmarshal([]byte(src), &s), "boolean prefixItems must parse")
+
+	items := s.PrefixItems()
+	require.Len(t, items, 3)
+
+	first, ok := items[0].(schema.BoolSchema)
+	require.True(t, ok, "items[0] should be a BoolSchema")
+	require.True(t, bool(first))
+
+	_, ok = items[1].(*schema.Schema)
+	require.True(t, ok, "items[1] should be a *Schema")
+
+	last, ok := items[2].(schema.BoolSchema)
+	require.True(t, ok, "items[2] should be a BoolSchema")
+	require.False(t, bool(last))
+
+	// Round-trips back to JSON without error.
+	_, err := json.Marshal(&s)
+	require.NoError(t, err)
+}

--- a/schema_prefixitems_test.go
+++ b/schema_prefixitems_test.go
@@ -5,36 +5,60 @@ import (
 	"testing"
 
 	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
 	"github.com/stretchr/testify/require"
 )
 
-// TestPrefixItemsBooleanSchema guards against a regression where prefixItems
-// elements were typed as *Schema and could not represent boolean schemas
-// (true/false), even though JSON Schema 2020-12 allows any schema — including a
-// boolean — as a prefixItems element.
+// In JSON Schema a "schema" is either an object (e.g. {"type":"string"}) or a
+// boolean: `true` is the schema that accepts every value, and `false` is the
+// schema that rejects every value. prefixItems applies a schema to each array
+// position by index, and since each entry is itself a schema, an entry may be a
+// boolean as well as an object.
+//
+// So prefixItems: [true, {"type":"string"}, false] reads as:
+//   - position 0: `true`  -> any value is allowed here
+//   - position 1: object  -> the value must be a string
+//   - position 2: `false` -> no value is allowed at this position
+//
+// These tests pin down both that such a schema parses and what it means when
+// validating data.
 func TestPrefixItemsBooleanSchema(t *testing.T) {
-	const src = `{
-		"prefixItems": [true, {"const": "bar"}, false]
-	}`
+	const src = `{"prefixItems": [true, {"type": "string"}, false]}`
 
-	var s schema.Schema
-	require.NoError(t, json.Unmarshal([]byte(src), &s), "boolean prefixItems must parse")
+	t.Run("boolean entries are preserved as boolean schemas", func(t *testing.T) {
+		var s schema.Schema
+		require.NoError(t, json.Unmarshal([]byte(src), &s))
 
-	items := s.PrefixItems()
-	require.Len(t, items, 3)
+		items := s.PrefixItems()
+		require.Len(t, items, 3)
 
-	first, ok := items[0].(schema.BoolSchema)
-	require.True(t, ok, "items[0] should be a BoolSchema")
-	require.True(t, bool(first))
+		// A bare `true`/`false` round-trips as a BoolSchema, not a *Schema.
+		require.Equal(t, schema.BoolSchema(true), items[0])
+		require.IsType(t, (*schema.Schema)(nil), items[1])
+		require.Equal(t, schema.BoolSchema(false), items[2])
 
-	_, ok = items[1].(*schema.Schema)
-	require.True(t, ok, "items[1] should be a *Schema")
+		_, err := json.Marshal(&s)
+		require.NoError(t, err)
+	})
 
-	last, ok := items[2].(schema.BoolSchema)
-	require.True(t, ok, "items[2] should be a BoolSchema")
-	require.False(t, bool(last))
+	t.Run("the boolean entries control validation per position", func(t *testing.T) {
+		var s schema.Schema
+		require.NoError(t, json.Unmarshal([]byte(src), &s))
+		v, err := validator.Compile(t.Context(), &s)
+		require.NoError(t, err)
 
-	// Round-trips back to JSON without error.
-	_, err := json.Marshal(&s)
-	require.NoError(t, err)
+		// position 0 is `true`, so even a non-string (42) is accepted there;
+		// position 1 is a string and "hello" satisfies it; there is no third
+		// element, so the `false` at position 2 never applies.
+		_, err = v.Validate(t.Context(), []any{42, "hello"})
+		require.NoError(t, err, "true accepts any value at position 0")
+
+		// position 1 must be a string; 99 is not.
+		_, err = v.Validate(t.Context(), []any{42, 99})
+		require.Error(t, err, "the object schema at position 1 rejects a non-string")
+
+		// position 2 is `false`: any value present there is rejected.
+		_, err = v.Validate(t.Context(), []any{42, "hello", "anything"})
+		require.Error(t, err, "false rejects whatever value appears at position 2")
+	})
 }

--- a/validator/array.go
+++ b/validator/array.go
@@ -29,7 +29,7 @@ func compileArrayValidator(ctx context.Context, s *schema.Schema, strictType boo
 		if prefixItems := s.PrefixItems(); len(prefixItems) > 0 {
 			prefixValidators := make([]Interface, len(prefixItems))
 			for i, prefixSchema := range prefixItems {
-				prefixValidator, err := Compile(ctx, prefixSchema)
+				prefixValidator, err := Compile(ctx, convertSchemaOrBool(prefixSchema))
 				if err != nil {
 					return nil, fmt.Errorf("failed to compile prefixItems[%d] validator: %w", i, err)
 				}

--- a/validator/array_test.go
+++ b/validator/array_test.go
@@ -295,7 +295,7 @@ func TestArrayValidatorComprehensive(t *testing.T) {
 		testCases := []struct {
 			name            string
 			value           []any
-			prefixItems     []*schema.Schema
+			prefixItems     []schema.SchemaOrBool
 			additionalItems any // bool or *schema.Schema
 			wantErr         bool
 			errMsg          string
@@ -303,7 +303,7 @@ func TestArrayValidatorComprehensive(t *testing.T) {
 			{
 				name:  "exact tuple match",
 				value: []any{"John", 30, true},
-				prefixItems: []*schema.Schema{
+				prefixItems: []schema.SchemaOrBool{
 					schema.NewBuilder().Types(schema.StringType).MustBuild(),
 					schema.NewBuilder().Types(schema.IntegerType).MustBuild(),
 					schema.NewBuilder().Types(schema.BooleanType).MustBuild(),
@@ -313,7 +313,7 @@ func TestArrayValidatorComprehensive(t *testing.T) {
 			{
 				name:  "tuple with fewer items",
 				value: []any{"John", 30},
-				prefixItems: []*schema.Schema{
+				prefixItems: []schema.SchemaOrBool{
 					schema.NewBuilder().Types(schema.StringType).MustBuild(),
 					schema.NewBuilder().Types(schema.IntegerType).MustBuild(),
 					schema.NewBuilder().Types(schema.BooleanType).MustBuild(),
@@ -323,7 +323,7 @@ func TestArrayValidatorComprehensive(t *testing.T) {
 			{
 				name:  "tuple type mismatch",
 				value: []any{123, 30, true}, // first should be string
-				prefixItems: []*schema.Schema{
+				prefixItems: []schema.SchemaOrBool{
 					schema.NewBuilder().Types(schema.StringType).MustBuild(),
 					schema.NewBuilder().Types(schema.IntegerType).MustBuild(),
 					schema.NewBuilder().Types(schema.BooleanType).MustBuild(),
@@ -334,7 +334,7 @@ func TestArrayValidatorComprehensive(t *testing.T) {
 			{
 				name:  "additional items allowed",
 				value: []any{"John", 30, true, "extra", 42},
-				prefixItems: []*schema.Schema{
+				prefixItems: []schema.SchemaOrBool{
 					schema.NewBuilder().Types(schema.StringType).MustBuild(),
 					schema.NewBuilder().Types(schema.IntegerType).MustBuild(),
 					schema.NewBuilder().Types(schema.BooleanType).MustBuild(),
@@ -345,7 +345,7 @@ func TestArrayValidatorComprehensive(t *testing.T) {
 			{
 				name:  "additional items forbidden",
 				value: []any{"John", 30, true, "extra"},
-				prefixItems: []*schema.Schema{
+				prefixItems: []schema.SchemaOrBool{
 					schema.NewBuilder().Types(schema.StringType).MustBuild(),
 					schema.NewBuilder().Types(schema.IntegerType).MustBuild(),
 					schema.NewBuilder().Types(schema.BooleanType).MustBuild(),
@@ -357,7 +357,7 @@ func TestArrayValidatorComprehensive(t *testing.T) {
 			{
 				name:  "additional items with schema - valid strings",
 				value: []any{"John", 30, true, "extra1", "extra2"},
-				prefixItems: []*schema.Schema{
+				prefixItems: []schema.SchemaOrBool{
 					schema.NewBuilder().Types(schema.StringType).MustBuild(),
 					schema.NewBuilder().Types(schema.IntegerType).MustBuild(),
 					schema.NewBuilder().Types(schema.BooleanType).MustBuild(),
@@ -368,7 +368,7 @@ func TestArrayValidatorComprehensive(t *testing.T) {
 			{
 				name:  "additional items violate schema",
 				value: []any{"John", 30, true, 123}, // additional should be string
-				prefixItems: []*schema.Schema{
+				prefixItems: []schema.SchemaOrBool{
 					schema.NewBuilder().Types(schema.StringType).MustBuild(),
 					schema.NewBuilder().Types(schema.IntegerType).MustBuild(),
 					schema.NewBuilder().Types(schema.BooleanType).MustBuild(),


### PR DESCRIPTION
- Type `prefixItems` as `[]SchemaOrBool` (was `[]*Schema`); JSON Schema 2020-12 allows a boolean schema as a prefixItems element, which `*Schema` couldn't represent — `prefixItems: [true, {…}]` failed to parse and cascaded up through enclosing `anyOf`/`oneOf`
- Change is in `objects.yml`; `schema_gen.go`/`builder_gen.go` regenerated. `validator/array.go` now wraps prefix elements via `convertSchemaOrBool`, mirroring `items`
- Add regression test for boolean prefixItems parse + round-trip
- Unblocks the official suite's `unevaluated*`×composition cases (they previously failed to parse); with #8's coordinator fix already in main, official failures across those files drop to a single unrelated "cousins" case
