### PR TITLE
test exported pattern helpers and ArrayResult

### DIFF
--- a/primitives_scalar_test.go
+++ b/primitives_scalar_test.go
@@ -1,0 +1,33 @@
+package schema_test
+
+import (
+	"testing"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/stretchr/testify/require"
+)
+
+// IsScalarPrimitiveType reports whether a primitive type is a scalar (leaf)
+// type as opposed to a container type (object/array). The JSON Schema spec
+// distinguishes "container instances" (arrays and objects) from the rest; this
+// helper is the inverse of that classification.
+func TestIsScalarPrimitiveType(t *testing.T) {
+	scalars := []schema.PrimitiveType{
+		schema.StringType,
+		schema.IntegerType,
+		schema.NumberType,
+		schema.BooleanType,
+		schema.NullType,
+	}
+	for _, typ := range scalars {
+		require.True(t, schema.IsScalarPrimitiveType(typ), "%s should be scalar", typ)
+	}
+
+	containers := []schema.PrimitiveType{
+		schema.ObjectType,
+		schema.ArrayType,
+	}
+	for _, typ := range containers {
+		require.False(t, schema.IsScalarPrimitiveType(typ), "%s should not be scalar", typ)
+	}
+}

--- a/validator/array_result_test.go
+++ b/validator/array_result_test.go
@@ -1,0 +1,35 @@
+package validator_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/json-schema/validator"
+	"github.com/stretchr/testify/require"
+)
+
+// ArrayResult tracks which array indices were evaluated, for unevaluatedItems
+// accounting. SetEvaluatedItem marks one index; SetEvaluatedItems replaces the
+// whole annotation slice in one call (e.g. when a caller has already computed
+// the full evaluated-items vector).
+func TestArrayResultEvaluatedItems(t *testing.T) {
+	t.Run("SetEvaluatedItem marks individual indices and grows the slice", func(t *testing.T) {
+		r := validator.NewArrayResult()
+		r.SetEvaluatedItem(2)
+		require.Equal(t, []bool{false, false, true}, r.EvaluatedItems())
+	})
+
+	t.Run("SetEvaluatedItems replaces the entire slice", func(t *testing.T) {
+		r := validator.NewArrayResult()
+		r.SetEvaluatedItem(0)
+		r.SetEvaluatedItems([]bool{false, true, true})
+		require.Equal(t, []bool{false, true, true}, r.EvaluatedItems())
+	})
+
+	t.Run("EvaluatedItems returns a copy, not the backing slice", func(t *testing.T) {
+		r := validator.NewArrayResult()
+		r.SetEvaluatedItems([]bool{true, true})
+		got := r.EvaluatedItems()
+		got[0] = false
+		require.Equal(t, []bool{true, true}, r.EvaluatedItems(), "mutating the returned slice must not affect the result")
+	})
+}

--- a/validator/string_test.go
+++ b/validator/string_test.go
@@ -929,6 +929,25 @@ func TestCommonPatterns(t *testing.T) {
 			valid:   []any{"abc123", "ABC", "123"},
 			invalid: []any{"hello-world", "with spaces", "special!", 123},
 		},
+		{
+			name:    "Date",
+			builder: schema.Date(),
+			valid:   []any{"2020-01-15", "1999-12-31"},
+			invalid: []any{"not-a-date", "2020-13-45", "2020/01/15", 123},
+		},
+		{
+			name:    "DateTime",
+			builder: schema.DateTime(),
+			valid:   []any{"2020-01-15T10:30:00Z", "2020-01-15T10:30:00"},
+			invalid: []any{"not-a-datetime", "2020-01-15", 123},
+		},
+		{
+			// Optional allows the wrapped schema's type or null.
+			name:    "Optional",
+			builder: schema.Optional(schema.NewBuilder().Types(schema.StringType).MustBuild()),
+			valid:   []any{"hello", nil},
+			invalid: []any{123, true},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
- Add behavioral tests (build → Compile → Validate) for previously-untested exported helpers: `Date`, `DateTime`, `Optional` (extends `TestCommonPatterns`)
- Add `IsScalarPrimitiveType` predicate test and `ArrayResult.SetEvaluatedItems`/`SetEvaluatedItem` test with copy semantics
- These exercise public API that was unused in-repo but is intended for consumers; no production code changes
- Documents a real nuance: `format` helpers (`Date`/`DateTime`/`Email`/…) only assert when the `format-assertion` vocabulary is enabled (annotation-only otherwise)
