### PR TITLE
wire resolver interfaces into validation

### DIFF
--- a/validator/array.go
+++ b/validator/array.go
@@ -257,181 +257,43 @@ func (b *ArrayValidatorBuilder) Reset() *ArrayValidatorBuilder {
 	return b
 }
 
-func (c *arrayValidator) Validate(ctx context.Context, v any) (Result, error) {
+// arrayAccessor provides uniform length/element access over an array instance,
+// backed either by a custom ArrayIndexResolver or by reflection on a slice/array.
+type arrayAccessor struct {
+	length int
+	at     func(int) (any, error)
+}
+
+// newArrayAccessor honors a custom ArrayIndexResolver first, then falls back to
+// reflection. The bool reports whether v is array-like at all.
+func newArrayAccessor(v any) (arrayAccessor, bool) {
+	if resolver, ok := v.(ArrayIndexResolver); ok {
+		return arrayAccessor{length: resolver.Len(), at: resolver.ResolveArrayIndex}, true
+	}
+
 	rv := reflect.ValueOf(v)
 	switch rv.Kind() {
 	case reflect.Ptr, reflect.Interface:
 		rv = rv.Elem()
 	}
+	switch rv.Kind() {
+	case reflect.Array, reflect.Slice:
+		return arrayAccessor{
+			length: rv.Len(),
+			at:     func(i int) (any, error) { return rv.Index(i).Interface(), nil },
+		}, true
+	default:
+		return arrayAccessor{}, false
+	}
+}
+
+func (c *arrayValidator) Validate(ctx context.Context, v any) (Result, error) {
+	acc, isArray := newArrayAccessor(v)
 
 	var ec schemactx.EvaluationContext
 	_ = schemactx.EvaluationContextFromContext(ctx, &ec)
 
-	switch rv.Kind() {
-	case reflect.Array, reflect.Slice:
-		length := uint(rv.Len())
-
-		// Check minItems constraint
-		if c.minItems != nil && length < *c.minItems {
-			return nil, fmt.Errorf(`invalid value passed to ArrayValidator: array length %d is below minimum items %d`, length, *c.minItems)
-		}
-
-		// Check maxItems constraint
-		if c.maxItems != nil && length > *c.maxItems {
-			return nil, fmt.Errorf(`invalid value passed to ArrayValidator: array length %d exceeds maximum items %d`, length, *c.maxItems)
-		}
-
-		// Check uniqueItems constraint
-		if c.uniqueItems && length > 0 {
-			for i := range rv.Len() {
-				item1 := rv.Index(i).Interface()
-				for j := i + 1; j < rv.Len(); j++ {
-					item2 := rv.Index(j).Interface()
-					if reflect.DeepEqual(item1, item2) {
-						return nil, fmt.Errorf(`invalid value passed to ArrayValidator: duplicate items found, uniqueItems violation`)
-					}
-				}
-			}
-		}
-
-		// Initialize result for tracking evaluated items
-		result := NewArrayResult()
-
-		// Merge evaluated items from previous validators
-		var evaluatedItems schemactx.EvaluatedItems
-		evaluatedItems.Copy(&ec.Items)
-
-		// Validate items according to prefixItems and items
-		arrayLength := rv.Len()
-		prefixItemsCount := len(c.prefixItems)
-
-		// First, validate items covered by prefixItems
-		for i := 0; i < arrayLength && i < prefixItemsCount; i++ {
-			item := rv.Index(i).Interface()
-			_, err := c.prefixItems[i].Validate(ctx, item)
-			if err != nil {
-				return nil, fmt.Errorf(`invalid value passed to ArrayValidator: prefixItems[%d] validation failed: %w`, i, err)
-			}
-			// Mark this item as evaluated by prefixItems
-			result.SetEvaluatedItem(i)
-		}
-
-		// Then, validate remaining items with the items schema (if present)
-		if c.items != nil {
-			for i := prefixItemsCount; i < arrayLength; i++ {
-				item := rv.Index(i).Interface()
-				_, err := c.items.Validate(ctx, item)
-				if err != nil {
-					return nil, fmt.Errorf(`invalid value passed to ArrayValidator: item validation failed: %w`, err)
-				}
-				// Mark this item as evaluated by items
-				result.SetEvaluatedItem(i)
-			}
-		}
-		// Note: Items beyond prefixItems that are not validated by items remain unevaluated
-
-		// Validate contains constraint and track evaluation
-		// According to JSON Schema spec, minContains and maxContains are ignored when contains is not present
-		// No validation needed when contains schema is absent
-		if c.contains != nil {
-			containsCount := uint(0)
-			for i := range rv.Len() {
-				item := rv.Index(i).Interface()
-				_, err := c.contains.Validate(ctx, item)
-				if err == nil {
-					containsCount++
-					// Mark this item as evaluated by contains
-					result.SetEvaluatedItem(i)
-				}
-			}
-
-			// Check minContains constraint first
-			if c.minContains != nil && containsCount < *c.minContains {
-				return nil, fmt.Errorf(`invalid value passed to ArrayValidator: minimum contains constraint failed: found %d, expected at least %d`, containsCount, *c.minContains)
-			}
-
-			// Check if any item matches the contains schema (only if minContains is not explicitly set to 0)
-			if containsCount == 0 && (c.minContains == nil || *c.minContains > 0) {
-				return nil, fmt.Errorf(`invalid value passed to ArrayValidator: does not contain required item`)
-			}
-
-			// Check maxContains constraint
-			if c.maxContains != nil && containsCount > *c.maxContains {
-				return nil, fmt.Errorf(`invalid value passed to ArrayValidator: maximum contains constraint failed: found %d, expected at most %d`, containsCount, *c.maxContains)
-			}
-		}
-
-		// Validate additionalItems for items beyond prefixItems
-		if c.additionalItems != nil {
-			// additionalItems only applies to indices beyond prefixItems
-			for i := prefixItemsCount; i < arrayLength; i++ {
-				// Only apply additionalItems if this item wasn't handled by items schema
-				if c.items == nil {
-					item := rv.Index(i).Interface()
-					_, err := c.additionalItems.Validate(ctx, item)
-					if err != nil {
-						return nil, fmt.Errorf(`invalid value passed to ArrayValidator: additionalItems validation failed: %w`, err)
-					}
-					result.SetEvaluatedItem(i)
-				}
-			}
-		}
-
-		// Handle unevaluatedItems validation
-		if c.unevaluatedItems != nil {
-			// Get evaluated items from context (from previous validators) AND current result
-			contextEvaluated := evaluatedItems.Values() // From previous validators
-			currentEvaluated := result.EvaluatedItems() // From current validator
-
-			// Merge context and current evaluations
-			maxLen := max(len(contextEvaluated), len(currentEvaluated))
-
-			mergedEvaluated := make([]bool, maxLen)
-			for i := range maxLen {
-				var contextVal, currentVal bool
-				if i < len(contextEvaluated) {
-					contextVal = contextEvaluated[i]
-				}
-				if i < len(currentEvaluated) {
-					currentVal = currentEvaluated[i]
-				}
-				mergedEvaluated[i] = contextVal || currentVal
-			}
-
-			// Validate unevaluated items
-			for i := range rv.Len() {
-				// Skip items that were already evaluated (by context or current validator)
-				if i < len(mergedEvaluated) && mergedEvaluated[i] {
-					continue
-				}
-
-				item := rv.Index(i).Interface()
-
-				// Handle boolean unevaluatedItems
-				if boolVal, ok := c.unevaluatedItems.(bool); ok {
-					if !boolVal {
-						// false means unevaluated items are not allowed
-						return nil, fmt.Errorf(`invalid value passed to ArrayValidator: unevaluated item at index %d not allowed`, i)
-					}
-					// true means unevaluated items are allowed - mark as evaluated
-					result.SetEvaluatedItem(i)
-					continue
-				}
-
-				// Handle schema unevaluatedItems
-				if validator, ok := c.unevaluatedItems.(Interface); ok {
-					_, err := validator.Validate(ctx, item)
-					if err != nil {
-						return nil, fmt.Errorf(`invalid value passed to ArrayValidator: unevaluated item validation failed at index %d: %w`, i, err)
-					}
-					// Mark as evaluated when schema validation passes
-					result.SetEvaluatedItem(i)
-				}
-			}
-		}
-
-		return result, nil
-	default:
+	if !isArray {
 		// Handle non-array values based on whether this is strict array type validation
 		if c.strictArrayType {
 			// When schema explicitly declares type: array, non-array values should fail
@@ -442,4 +304,188 @@ func (c *arrayValidator) Validate(ctx context.Context, v any) (Result, error) {
 		//nolint: nilnil
 		return nil, nil
 	}
+
+	length := uint(acc.length)
+
+	// Check minItems constraint
+	if c.minItems != nil && length < *c.minItems {
+		return nil, fmt.Errorf(`invalid value passed to ArrayValidator: array length %d is below minimum items %d`, length, *c.minItems)
+	}
+
+	// Check maxItems constraint
+	if c.maxItems != nil && length > *c.maxItems {
+		return nil, fmt.Errorf(`invalid value passed to ArrayValidator: array length %d exceeds maximum items %d`, length, *c.maxItems)
+	}
+
+	// Check uniqueItems constraint
+	if c.uniqueItems && length > 0 {
+		for i := range acc.length {
+			item1, err := acc.at(i)
+			if err != nil {
+				return nil, fmt.Errorf(`invalid value passed to ArrayValidator: failed to resolve item %d: %w`, i, err)
+			}
+			for j := i + 1; j < acc.length; j++ {
+				item2, err := acc.at(j)
+				if err != nil {
+					return nil, fmt.Errorf(`invalid value passed to ArrayValidator: failed to resolve item %d: %w`, j, err)
+				}
+				if reflect.DeepEqual(item1, item2) {
+					return nil, fmt.Errorf(`invalid value passed to ArrayValidator: duplicate items found, uniqueItems violation`)
+				}
+			}
+		}
+	}
+
+	// Initialize result for tracking evaluated items
+	result := NewArrayResult()
+
+	// Merge evaluated items from previous validators
+	var evaluatedItems schemactx.EvaluatedItems
+	evaluatedItems.Copy(&ec.Items)
+
+	// Validate items according to prefixItems and items
+	arrayLength := acc.length
+	prefixItemsCount := len(c.prefixItems)
+
+	// First, validate items covered by prefixItems
+	for i := 0; i < arrayLength && i < prefixItemsCount; i++ {
+		item, err := acc.at(i)
+		if err != nil {
+			return nil, fmt.Errorf(`invalid value passed to ArrayValidator: failed to resolve item %d: %w`, i, err)
+		}
+		_, err = c.prefixItems[i].Validate(ctx, item)
+		if err != nil {
+			return nil, fmt.Errorf(`invalid value passed to ArrayValidator: prefixItems[%d] validation failed: %w`, i, err)
+		}
+		// Mark this item as evaluated by prefixItems
+		result.SetEvaluatedItem(i)
+	}
+
+	// Then, validate remaining items with the items schema (if present)
+	if c.items != nil {
+		for i := prefixItemsCount; i < arrayLength; i++ {
+			item, err := acc.at(i)
+			if err != nil {
+				return nil, fmt.Errorf(`invalid value passed to ArrayValidator: failed to resolve item %d: %w`, i, err)
+			}
+			_, err = c.items.Validate(ctx, item)
+			if err != nil {
+				return nil, fmt.Errorf(`invalid value passed to ArrayValidator: item validation failed: %w`, err)
+			}
+			// Mark this item as evaluated by items
+			result.SetEvaluatedItem(i)
+		}
+	}
+	// Note: Items beyond prefixItems that are not validated by items remain unevaluated
+
+	// Validate contains constraint and track evaluation
+	// According to JSON Schema spec, minContains and maxContains are ignored when contains is not present
+	// No validation needed when contains schema is absent
+	if c.contains != nil {
+		containsCount := uint(0)
+		for i := range acc.length {
+			item, err := acc.at(i)
+			if err != nil {
+				return nil, fmt.Errorf(`invalid value passed to ArrayValidator: failed to resolve item %d: %w`, i, err)
+			}
+			_, err = c.contains.Validate(ctx, item)
+			if err == nil {
+				containsCount++
+				// Mark this item as evaluated by contains
+				result.SetEvaluatedItem(i)
+			}
+		}
+
+		// Check minContains constraint first
+		if c.minContains != nil && containsCount < *c.minContains {
+			return nil, fmt.Errorf(`invalid value passed to ArrayValidator: minimum contains constraint failed: found %d, expected at least %d`, containsCount, *c.minContains)
+		}
+
+		// Check if any item matches the contains schema (only if minContains is not explicitly set to 0)
+		if containsCount == 0 && (c.minContains == nil || *c.minContains > 0) {
+			return nil, fmt.Errorf(`invalid value passed to ArrayValidator: does not contain required item`)
+		}
+
+		// Check maxContains constraint
+		if c.maxContains != nil && containsCount > *c.maxContains {
+			return nil, fmt.Errorf(`invalid value passed to ArrayValidator: maximum contains constraint failed: found %d, expected at most %d`, containsCount, *c.maxContains)
+		}
+	}
+
+	// Validate additionalItems for items beyond prefixItems
+	if c.additionalItems != nil {
+		// additionalItems only applies to indices beyond prefixItems
+		for i := prefixItemsCount; i < arrayLength; i++ {
+			// Only apply additionalItems if this item wasn't handled by items schema
+			if c.items == nil {
+				item, err := acc.at(i)
+				if err != nil {
+					return nil, fmt.Errorf(`invalid value passed to ArrayValidator: failed to resolve item %d: %w`, i, err)
+				}
+				_, err = c.additionalItems.Validate(ctx, item)
+				if err != nil {
+					return nil, fmt.Errorf(`invalid value passed to ArrayValidator: additionalItems validation failed: %w`, err)
+				}
+				result.SetEvaluatedItem(i)
+			}
+		}
+	}
+
+	// Handle unevaluatedItems validation
+	if c.unevaluatedItems != nil {
+		// Get evaluated items from context (from previous validators) AND current result
+		contextEvaluated := evaluatedItems.Values() // From previous validators
+		currentEvaluated := result.EvaluatedItems() // From current validator
+
+		// Merge context and current evaluations
+		maxLen := max(len(contextEvaluated), len(currentEvaluated))
+
+		mergedEvaluated := make([]bool, maxLen)
+		for i := range maxLen {
+			var contextVal, currentVal bool
+			if i < len(contextEvaluated) {
+				contextVal = contextEvaluated[i]
+			}
+			if i < len(currentEvaluated) {
+				currentVal = currentEvaluated[i]
+			}
+			mergedEvaluated[i] = contextVal || currentVal
+		}
+
+		// Validate unevaluated items
+		for i := range acc.length {
+			// Skip items that were already evaluated (by context or current validator)
+			if i < len(mergedEvaluated) && mergedEvaluated[i] {
+				continue
+			}
+
+			item, err := acc.at(i)
+			if err != nil {
+				return nil, fmt.Errorf(`invalid value passed to ArrayValidator: failed to resolve item %d: %w`, i, err)
+			}
+
+			// Handle boolean unevaluatedItems
+			if boolVal, ok := c.unevaluatedItems.(bool); ok {
+				if !boolVal {
+					// false means unevaluated items are not allowed
+					return nil, fmt.Errorf(`invalid value passed to ArrayValidator: unevaluated item at index %d not allowed`, i)
+				}
+				// true means unevaluated items are allowed - mark as evaluated
+				result.SetEvaluatedItem(i)
+				continue
+			}
+
+			// Handle schema unevaluatedItems
+			if validator, ok := c.unevaluatedItems.(Interface); ok {
+				_, err := validator.Validate(ctx, item)
+				if err != nil {
+					return nil, fmt.Errorf(`invalid value passed to ArrayValidator: unevaluated item validation failed at index %d: %w`, i, err)
+				}
+				// Mark as evaluated when schema validation passes
+				result.SetEvaluatedItem(i)
+			}
+		}
+	}
+
+	return result, nil
 }

--- a/validator/object.go
+++ b/validator/object.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 
 	schema "github.com/lestrrat-go/json-schema"
 	"github.com/lestrrat-go/json-schema/internal/schemactx"
@@ -288,6 +289,60 @@ func (b *ObjectValidatorBuilder) Reset() *ObjectValidatorBuilder {
 	return b
 }
 
+// extractObjectProperties reads v as a JSON object into a name->value map. It
+// honors a custom ObjectFieldResolver first, then handles map and struct
+// instances (using the JSON tag's name, ignoring options like ",omitempty").
+// The bool reports whether v is object-like at all.
+func extractObjectProperties(v any) (map[string]any, bool, error) {
+	if resolver, ok := v.(ObjectFieldResolver); ok {
+		props := make(map[string]any)
+		for _, name := range resolver.FieldNames() {
+			val, err := resolver.ResolveObjectField(name)
+			if err != nil {
+				return nil, true, fmt.Errorf("failed to resolve field %q: %w", name, err)
+			}
+			props[name] = val
+		}
+		return props, true, nil
+	}
+
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		rv = rv.Elem()
+	}
+
+	switch rv.Kind() {
+	case reflect.Map:
+		props := make(map[string]any)
+		for _, key := range rv.MapKeys() {
+			props[key.String()] = rv.MapIndex(key).Interface()
+		}
+		return props, true, nil
+	case reflect.Struct:
+		props := make(map[string]any)
+		t := rv.Type()
+		for i := range rv.NumField() {
+			field := t.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			jsonTag := field.Tag.Get("json")
+			if jsonTag == "-" {
+				continue // json:"-" excludes the field
+			}
+			fieldName := field.Name
+			if tagName, _, _ := strings.Cut(jsonTag, ","); tagName != "" {
+				fieldName = tagName
+			}
+			props[fieldName] = rv.Field(i).Interface()
+		}
+		return props, true, nil
+	default:
+		return nil, false, nil
+	}
+}
+
 // Validate implements the Interface
 func (c *objectValidator) Validate(ctx context.Context, v any) (Result, error) {
 	// Get previously evaluated properties from context
@@ -296,35 +351,11 @@ func (c *objectValidator) Validate(ctx context.Context, v any) (Result, error) {
 	if ec == nil {
 		ec = &schemactx.EvaluationContext{}
 	}
-	rv := reflect.ValueOf(v)
-	switch rv.Kind() {
-	case reflect.Ptr, reflect.Interface:
-		rv = rv.Elem()
+	properties, isObject, err := extractObjectProperties(v)
+	if err != nil {
+		return nil, fmt.Errorf(`invalid value passed to ObjectValidator: %w`, err)
 	}
-
-	var properties map[string]any
-
-	switch rv.Kind() {
-	case reflect.Map:
-		properties = make(map[string]any)
-		for _, key := range rv.MapKeys() {
-			keyStr := key.String()
-			properties[keyStr] = rv.MapIndex(key).Interface()
-		}
-	case reflect.Struct:
-		properties = make(map[string]any)
-		t := rv.Type()
-		for i := range rv.NumField() {
-			field := t.Field(i)
-			if field.IsExported() {
-				fieldName := field.Name
-				if jsonTag := field.Tag.Get("json"); jsonTag != "" && jsonTag != "-" {
-					fieldName = jsonTag
-				}
-				properties[fieldName] = rv.Field(i).Interface()
-			}
-		}
-	default:
+	if !isObject {
 		// Handle non-object values based on whether this is strict object type validation
 		if c.strictObjectType {
 			// When schema explicitly declares type: object, non-object values should fail

--- a/validator/resolver_wiring_test.go
+++ b/validator/resolver_wiring_test.go
@@ -1,0 +1,96 @@
+package validator_test
+
+import (
+	"testing"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+	"github.com/stretchr/testify/require"
+)
+
+// opaqueObject is a custom type whose JSON representation the validator can only
+// learn through the ObjectFieldResolver interface (it is neither a map nor a
+// struct with the relevant fields). It demonstrates that, with FieldNames added
+// to the interface, enumeration-based keywords (additionalProperties,
+// minProperties, propertyNames) work through the resolver.
+type opaqueObject struct {
+	store map[string]any
+}
+
+func (o opaqueObject) FieldNames() []string {
+	names := make([]string, 0, len(o.store))
+	for k := range o.store {
+		names = append(names, k)
+	}
+	return names
+}
+
+func (o opaqueObject) ResolveObjectField(name string) (any, error) {
+	return o.store[name], nil
+}
+
+func TestObjectFieldResolverDrivesValidation(t *testing.T) {
+	nameSchema := schema.NewBuilder().Types(schema.StringType).MinLength(1).MustBuild()
+	s, err := schema.NewBuilder().
+		Types(schema.ObjectType).
+		Property("name", nameSchema).
+		Required("name").
+		AdditionalProperties(schema.FalseSchema()).
+		Build()
+	require.NoError(t, err)
+	v, err := validator.Compile(t.Context(), s)
+	require.NoError(t, err)
+
+	t.Run("resolver-only object validates via properties + required", func(t *testing.T) {
+		_, err := v.Validate(t.Context(), opaqueObject{store: map[string]any{"name": "ok"}})
+		require.NoError(t, err)
+	})
+
+	t.Run("enumeration sees an extra field and additionalProperties:false rejects it", func(t *testing.T) {
+		_, err := v.Validate(t.Context(), opaqueObject{store: map[string]any{"name": "ok", "extra": 1}})
+		require.Error(t, err, "FieldNames must expose 'extra' so additionalProperties:false can reject it")
+	})
+
+	t.Run("required missing is detected through the resolver", func(t *testing.T) {
+		_, err := v.Validate(t.Context(), opaqueObject{store: map[string]any{}})
+		require.Error(t, err)
+	})
+}
+
+// opaqueArray is reachable only through the ArrayIndexResolver interface,
+// demonstrating that Len() lets length-based keywords (minItems/maxItems) and
+// per-item keywords (prefixItems/items) work through the resolver.
+type opaqueArray struct {
+	elems []any
+}
+
+func (o opaqueArray) Len() int { return len(o.elems) }
+
+func (o opaqueArray) ResolveArrayIndex(i int) (any, error) { return o.elems[i], nil }
+
+func TestArrayIndexResolverDrivesValidation(t *testing.T) {
+	elemSchema := schema.NewBuilder().Types(schema.StringType).MustBuild()
+	s, err := schema.NewBuilder().
+		Types(schema.ArrayType).
+		Items(elemSchema).
+		MinItems(2).
+		Build()
+	require.NoError(t, err)
+	v, err := validator.Compile(t.Context(), s)
+	require.NoError(t, err)
+
+	t.Run("items + minItems satisfied through the resolver", func(t *testing.T) {
+		_, err := v.Validate(t.Context(), opaqueArray{elems: []any{"a", "b"}})
+		require.NoError(t, err)
+	})
+
+	t.Run("minItems uses Len() from the resolver", func(t *testing.T) {
+		_, err := v.Validate(t.Context(), opaqueArray{elems: []any{"a"}})
+		require.Error(t, err)
+	})
+
+	t.Run("items schema applied to resolver elements", func(t *testing.T) {
+		_, err := v.Validate(t.Context(), opaqueArray{elems: []any{"a", 42}})
+		require.Error(t, err, "non-string element must fail the items schema")
+	})
+}

--- a/validator/validation_targets_test.go
+++ b/validator/validation_targets_test.go
@@ -7,141 +7,105 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestValidationTargets tests the validation target resolution functionality
+// TestValidationTargets exercises the instance-access helpers that back object
+// and array validation: extractObjectProperties and newArrayAccessor.
 func TestValidationTargets(t *testing.T) {
-	t.Run("ObjectFieldResolver interface", func(t *testing.T) {
-		obj := &testObjectResolver{
-			fields: map[string]any{
-				"name": "John",
-				"age":  30,
-			},
-		}
-
-		value, err := resolveObjectField(obj, "name")
+	t.Run("ObjectFieldResolver drives extractObjectProperties", func(t *testing.T) {
+		obj := &testObjectResolver{fields: map[string]any{"name": "John", "age": 30}}
+		props, ok, err := extractObjectProperties(obj)
 		require.NoError(t, err)
-		require.Equal(t, "John", value)
+		require.True(t, ok)
+		require.Equal(t, "John", props["name"])
+		require.Equal(t, 30, props["age"])
+		_, exists := props["missing"]
+		require.False(t, exists)
+	})
 
-		value, err = resolveObjectField(obj, "age")
+	t.Run("ArrayIndexResolver drives newArrayAccessor", func(t *testing.T) {
+		arr := &testArrayResolver{items: []any{"first", "second", "third"}}
+		acc, ok := newArrayAccessor(arr)
+		require.True(t, ok)
+		require.Equal(t, 3, acc.length)
+
+		v0, err := acc.at(0)
 		require.NoError(t, err)
-		require.Equal(t, 30, value)
+		require.Equal(t, "first", v0)
 
-		_, err = resolveObjectField(obj, "missing")
+		v2, err := acc.at(2)
+		require.NoError(t, err)
+		require.Equal(t, "third", v2)
+
+		_, err = acc.at(10)
 		require.Error(t, err)
 	})
 
-	t.Run("ArrayIndexResolver interface", func(t *testing.T) {
-		arr := &testArrayResolver{
-			items: []any{"first", "second", "third"},
-		}
-
-		value, err := resolveArrayIndex(arr, 0)
+	t.Run("map object extraction", func(t *testing.T) {
+		props, ok, err := extractObjectProperties(map[string]any{"foo": "bar", "baz": 42})
 		require.NoError(t, err)
-		require.Equal(t, "first", value)
-
-		value, err = resolveArrayIndex(arr, 2)
-		require.NoError(t, err)
-		require.Equal(t, "third", value)
-
-		_, err = resolveArrayIndex(arr, 10)
-		require.Error(t, err)
+		require.True(t, ok)
+		require.Equal(t, "bar", props["foo"])
+		require.Equal(t, 42, props["baz"])
 	})
 
-	t.Run("Map object field resolution", func(t *testing.T) {
-		obj := map[string]any{
-			"foo": "bar",
-			"baz": 42,
-		}
-
-		value, err := resolveObjectField(obj, "foo")
-		require.NoError(t, err)
-		require.Equal(t, "bar", value)
-
-		value, err = resolveObjectField(obj, "baz")
-		require.NoError(t, err)
-		require.Equal(t, 42, value)
-
-		_, err = resolveObjectField(obj, "missing")
-		require.Error(t, err)
-	})
-
-	t.Run("Struct field resolution with JSON tags", func(t *testing.T) {
+	t.Run("struct extraction keys on json tag names", func(t *testing.T) {
 		type TestStruct struct {
-			Name string `json:"name"`
-			Age  int    `json:"age"`
-			Bar  string `json:"baz"` // JSON field name differs from struct field
-			Qux  string // No JSON tag, should match field name
+			Name   string `json:"name"`
+			Age    int    `json:"age"`
+			Bar    string `json:"baz"`           // renamed via tag
+			Opt    string `json:"opt,omitempty"` // tag options must be ignored
+			Hidden string `json:"-"`             // excluded entirely
+			Qux    string // no tag -> exact field name
 		}
+		obj := TestStruct{Name: "Alice", Age: 25, Bar: "hello", Opt: "o", Hidden: "secret", Qux: "world"}
 
-		obj := TestStruct{
-			Name: "Alice",
-			Age:  25,
-			Bar:  "hello",
-			Qux:  "world",
-		}
-
-		// Test JSON tag resolution
-		value, err := resolveObjectField(obj, "name")
+		props, ok, err := extractObjectProperties(obj)
 		require.NoError(t, err)
-		require.Equal(t, "Alice", value)
+		require.True(t, ok)
+		require.Equal(t, "Alice", props["name"])
+		require.Equal(t, 25, props["age"])
+		require.Equal(t, "hello", props["baz"])
+		require.Equal(t, "o", props["opt"], "tag option ,omitempty must not be part of the key")
+		require.Equal(t, "world", props["Qux"])
 
-		value, err = resolveObjectField(obj, "age")
-		require.NoError(t, err)
-		require.Equal(t, 25, value)
-
-		// Test JSON tag with different field name
-		value, err = resolveObjectField(obj, "baz")
-		require.NoError(t, err)
-		require.Equal(t, "hello", value)
-
-		// Test field name without JSON tag
-		value, err = resolveObjectField(obj, "qux")
-		require.NoError(t, err)
-		require.Equal(t, "world", value)
-
-		// Test case-insensitive matching
-		value, err = resolveObjectField(obj, "Qux")
-		require.NoError(t, err)
-		require.Equal(t, "world", value)
-
-		// Test missing field
-		_, err = resolveObjectField(obj, "missing")
-		require.Error(t, err)
+		_, hidden := props["Hidden"]
+		require.False(t, hidden, `json:"-" field must be excluded`)
 	})
 
-	t.Run("Slice array index resolution", func(t *testing.T) {
-		arr := []any{"a", "b", "c"}
-
-		value, err := resolveArrayIndex(arr, 0)
+	t.Run("slice array accessor", func(t *testing.T) {
+		acc, ok := newArrayAccessor([]any{"a", "b", "c"})
+		require.True(t, ok)
+		require.Equal(t, 3, acc.length)
+		v, err := acc.at(0)
 		require.NoError(t, err)
-		require.Equal(t, "a", value)
+		require.Equal(t, "a", v)
+	})
 
-		value, err = resolveArrayIndex(arr, 2)
+	t.Run("non-object and non-array are reported via the bool", func(t *testing.T) {
+		_, ok, err := extractObjectProperties(42)
 		require.NoError(t, err)
-		require.Equal(t, "c", value)
+		require.False(t, ok)
 
-		_, err = resolveArrayIndex(arr, 5)
-		require.Error(t, err)
-
-		_, err = resolveArrayIndex(arr, -1)
-		require.Error(t, err)
+		_, ok = newArrayAccessor(42)
+		require.False(t, ok)
 	})
 
 	t.Run("NewArrayResult with size parameter", func(t *testing.T) {
-		// Test without size parameter
-		result1 := NewArrayResult()
-		require.NotNil(t, result1)
-		require.Equal(t, 0, len(result1.EvaluatedItems()))
-
-		// Test with size parameter
-		result2 := NewArrayResult(10)
-		require.NotNil(t, result2)
-		require.Equal(t, 0, len(result2.EvaluatedItems()))
+		require.Equal(t, 0, len(NewArrayResult().EvaluatedItems()))
+		require.Equal(t, 0, len(NewArrayResult(10).EvaluatedItems()))
 	})
 }
 
 // testObjectResolver implements ObjectFieldResolver for testing
 type testObjectResolver struct {
 	fields map[string]any
+}
+
+func (t *testObjectResolver) FieldNames() []string {
+	names := make([]string, 0, len(t.fields))
+	for name := range t.fields {
+		names = append(names, name)
+	}
+	return names
 }
 
 func (t *testObjectResolver) ResolveObjectField(field string) (any, error) {
@@ -155,6 +119,8 @@ func (t *testObjectResolver) ResolveObjectField(field string) (any, error) {
 type testArrayResolver struct {
 	items []any
 }
+
+func (t *testArrayResolver) Len() int { return len(t.items) }
 
 func (t *testArrayResolver) ResolveArrayIndex(index int) (any, error) {
 	if index < 0 || index >= len(t.items) {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"reflect"
-	"strings"
 
 	schema "github.com/lestrrat-go/json-schema"
 )
@@ -21,115 +19,21 @@ type Interface interface {
 // by other validators (e.g., for unevaluatedProperties tracking)
 type Result any
 
-// ObjectFieldResolver allows custom resolution of object fields
+// ObjectFieldResolver allows a custom Go type to control how the validator
+// reads it as a JSON object. FieldNames enumerates the properties present
+// (needed for additionalProperties, unevaluatedProperties, propertyNames,
+// minProperties/maxProperties); ResolveObjectField returns a property's value.
 type ObjectFieldResolver interface {
+	FieldNames() []string
 	ResolveObjectField(string) (any, error)
 }
 
-// ArrayIndexResolver allows custom resolution of array indices
+// ArrayIndexResolver allows a custom Go type to control how the validator reads
+// it as a JSON array. Len reports the element count (needed for
+// minItems/maxItems and iteration); ResolveArrayIndex returns an element.
 type ArrayIndexResolver interface {
+	Len() int
 	ResolveArrayIndex(int) (any, error)
-}
-
-// resolveObjectField resolves a field from an object, supporting multiple types:
-// - map[string]any: direct key lookup
-// - ObjectFieldResolver: custom resolution
-// - struct: reflection with JSON tag support
-func resolveObjectField(obj any, fieldName string) (any, error) {
-	if obj == nil {
-		return nil, fmt.Errorf("cannot resolve field %q from nil object", fieldName)
-	}
-
-	// Try ObjectFieldResolver interface first
-	if resolver, ok := obj.(ObjectFieldResolver); ok {
-		return resolver.ResolveObjectField(fieldName)
-	}
-
-	// Handle map[string]any directly
-	if m, ok := obj.(map[string]any); ok {
-		if value, exists := m[fieldName]; exists {
-			return value, nil
-		}
-		return nil, fmt.Errorf("field %q not found in object", fieldName)
-	}
-
-	// Handle struct types using reflection
-	return resolveStructField(obj, fieldName)
-}
-
-// resolveArrayIndex resolves an element from an array, supporting multiple types:
-// - []any: direct index access
-// - ArrayIndexResolver: custom resolution
-func resolveArrayIndex(arr any, index int) (any, error) {
-	if arr == nil {
-		return nil, fmt.Errorf("cannot resolve index %d from nil array", index)
-	}
-
-	// Try ArrayIndexResolver interface first
-	if resolver, ok := arr.(ArrayIndexResolver); ok {
-		return resolver.ResolveArrayIndex(index)
-	}
-
-	// Handle slice types using reflection
-	rv := reflect.ValueOf(arr)
-	if rv.Kind() == reflect.Ptr {
-		rv = rv.Elem()
-	}
-
-	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
-		return nil, fmt.Errorf("value is not an array or slice, got %T", arr)
-	}
-
-	if index < 0 || index >= rv.Len() {
-		return nil, fmt.Errorf("index %d out of bounds for array of length %d", index, rv.Len())
-	}
-
-	return rv.Index(index).Interface(), nil
-}
-
-// resolveStructField resolves a field from a struct using reflection and JSON tags
-func resolveStructField(obj any, fieldName string) (any, error) {
-	rv := reflect.ValueOf(obj)
-	if rv.Kind() == reflect.Ptr {
-		rv = rv.Elem()
-	}
-
-	if rv.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("value is not a struct, got %T", obj)
-	}
-
-	rt := rv.Type()
-
-	// First, try to find field by JSON tag
-	for i := range rt.NumField() {
-		field := rt.Field(i)
-
-		// Skip unexported fields
-		if !field.IsExported() {
-			continue
-		}
-
-		// Check JSON tag
-		jsonTag := field.Tag.Get("json")
-		if jsonTag != "" {
-			// Parse JSON tag (field name is before first comma)
-			tagName := strings.Split(jsonTag, ",")[0]
-			if tagName == fieldName {
-				return rv.Field(i).Interface(), nil
-			}
-			// Skip if tag explicitly sets a different name
-			if tagName != "" && tagName != "-" {
-				continue
-			}
-		}
-
-		// Check if field name matches (case-insensitive for JSON compatibility)
-		if strings.EqualFold(field.Name, fieldName) {
-			return rv.Field(i).Interface(), nil
-		}
-	}
-
-	return nil, fmt.Errorf("field %q not found in struct %T", fieldName, obj)
 }
 
 // ObjectResult contains information about which object properties were evaluated


### PR DESCRIPTION
- Make `ObjectFieldResolver`/`ArrayIndexResolver` functional: add `FieldNames()`/`Len()` so the enumeration keywords (additionalProperties, unevaluatedProperties, propertyNames, min/maxProperties, min/maxItems) work through a custom resolver — previously the interfaces were exported but never consulted by the validators
- Route object access through `extractObjectProperties` and array access through `arrayAccessor`; a custom type that is neither map nor slice can now drive validation (see resolver_wiring_test.go)
- Fix struct JSON-tag parsing: use the name before the first comma and honor `json:"-"`, so `json:"name,omitempty"` no longer breaks `required`/`properties`
- Remove the superseded per-field `resolveObjectField`/`resolveArrayIndex`/`resolveStructField`; repoint their test at the new helpers
- Breaking: the two interfaces gain a method each (intentional — the old shape was non-functional)
