### PR TITLE
isolate allOf cousin annotations

### DIFF
--- a/validator/allof_cousin_test.go
+++ b/validator/allof_cousin_test.go
@@ -1,0 +1,60 @@
+package validator_test
+
+import (
+	"testing"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+	"github.com/stretchr/testify/require"
+)
+
+// allOf subschemas are "cousins": one branch's evaluated items/properties must
+// not be visible to a sibling branch's unevaluatedItems/unevaluatedProperties.
+// Annotations only flow upward to the parent, never sideways between branches.
+func TestAllOfCousinAnnotationIsolation(t *testing.T) {
+	t.Run("unevaluatedItems cannot see a cousin branch's prefixItems", func(t *testing.T) {
+		// { "allOf": [ {"prefixItems":[true]}, {"unevaluatedItems":false} ] }
+		// prefixItems is in allOf[0]; unevaluatedItems is in allOf[1]. From
+		// allOf[1]'s view index 0 is unevaluated, so false must reject it.
+		branchA := schema.NewBuilder().PrefixItems(schema.TrueSchema()).MustBuild()
+		branchB := schema.NewBuilder().UnevaluatedItems(schema.FalseSchema()).MustBuild()
+		s, err := schema.NewBuilder().AllOf(branchA, branchB).Build()
+		require.NoError(t, err)
+		v, err := validator.Compile(t.Context(), s)
+		require.NoError(t, err)
+
+		_, err = v.Validate(t.Context(), []any{1})
+		require.Error(t, err, "cousin branch's prefixItems must not satisfy unevaluatedItems:false")
+	})
+
+	t.Run("unevaluatedProperties cannot see a cousin branch's properties", func(t *testing.T) {
+		// Object analog: properties in allOf[0], unevaluatedProperties:false in allOf[1].
+		fooSchema := schema.NewBuilder().Types(schema.StringType).MustBuild()
+		branchA := schema.NewBuilder().Property("foo", fooSchema).MustBuild()
+		branchB := schema.NewBuilder().UnevaluatedProperties(schema.FalseSchema()).MustBuild()
+		s, err := schema.NewBuilder().AllOf(branchA, branchB).Build()
+		require.NoError(t, err)
+		v, err := validator.Compile(t.Context(), s)
+		require.NoError(t, err)
+
+		_, err = v.Validate(t.Context(), map[string]any{"foo": "bar"})
+		require.Error(t, err, "cousin branch's properties must not satisfy unevaluatedProperties:false")
+	})
+
+	t.Run("parent-level unevaluatedItems still sees allOf branches (upward merge)", func(t *testing.T) {
+		// { "prefixItems":[...] hidden in allOf, unevaluatedItems:false at parent }
+		// Here unevaluatedItems is the PARENT of allOf, so the branch's annotation
+		// must reach it and the item is evaluated -> valid.
+		branch := schema.NewBuilder().PrefixItems(schema.TrueSchema()).MustBuild()
+		s, err := schema.NewBuilder().
+			AllOf(branch).
+			UnevaluatedItems(schema.FalseSchema()).
+			Build()
+		require.NoError(t, err)
+		v, err := validator.Compile(t.Context(), s)
+		require.NoError(t, err)
+
+		_, err = v.Validate(t.Context(), []any{1})
+		require.NoError(t, err, "parent unevaluatedItems must see the allOf branch's prefixItems")
+	})
+}

--- a/validator/multi.go
+++ b/validator/multi.go
@@ -29,13 +29,14 @@ type allOfValidator struct {
 }
 
 func (v *allOfValidator) Validate(ctx context.Context, in any) (Result, error) {
-	// Use executeValidatorsWithContextFlow with context flow for array items
-	// NOTE: We do NOT pass evaluated properties between allOf subschemas
-	// This implements the "cousin" semantics where properties evaluated by one
-	// subschema are not visible to other subschemas in the same allOf
-	merger, err := executeValidatorsWithContextFlow(ctx, v.validators, in)
+	// allOf subschemas are "cousins": each is evaluated independently and none
+	// can see the items/properties evaluated by another. Their annotations are
+	// merged upward for the parent (so a parent-level unevaluatedItems /
+	// unevaluatedProperties does see them), but they are NOT shared sideways
+	// between branches.
+	merger, err := executeValidatorsAndMergeResults(ctx, v.validators, in, "allOf")
 	if err != nil {
-		return nil, fmt.Errorf(`allOf validation failed: %w`, err)
+		return nil, err
 	}
 	return merger.FinalResult(), nil
 }

--- a/validator/validation_utils.go
+++ b/validator/validation_utils.go
@@ -3,8 +3,6 @@ package validator
 import (
 	"context"
 	"fmt"
-
-	"github.com/lestrrat-go/json-schema/internal/schemactx"
 )
 
 // resultMerger handles the common pattern of merging ObjectResult and ArrayResult
@@ -81,29 +79,6 @@ func (rm *resultMerger) ArrayResult() *ArrayResult {
 	return rm.arrayResult
 }
 
-// withEvaluatedItems creates a new context with evaluated items
-func withEvaluatedItems(ctx context.Context, evaluatedItems []bool) context.Context {
-	if len(evaluatedItems) == 0 {
-		return ctx
-	}
-
-	// Get existing evaluation context or create a new one
-	var ec *schemactx.EvaluationContext
-	_ = schemactx.EvaluationContextFromContext(ctx, &ec)
-	if ec == nil {
-		ec = &schemactx.EvaluationContext{}
-	}
-
-	// Copy evaluated items
-	for i, evaluated := range evaluatedItems {
-		if evaluated {
-			ec.Items.Set(i, true)
-		}
-	}
-
-	return schemactx.WithEvaluationContext(ctx, ec)
-}
-
 // executeValidatorsAndMergeResults executes all validators and merges their results
 // Returns the result merger and any error encountered
 func executeValidatorsAndMergeResults(ctx context.Context, validators []Interface, input any, validatorType string) (*resultMerger, error) {
@@ -114,32 +89,6 @@ func executeValidatorsAndMergeResults(ctx context.Context, validators []Interfac
 		if err != nil {
 			return nil, fmt.Errorf(`%s validation failed: validator #%d failed: %w`, validatorType, i, err)
 		}
-		merger.mergeResult(result)
-	}
-
-	return &merger, nil
-}
-
-// executeValidatorsWithContextFlow executes validators with context flow for array items
-// (items annotations flow between validators)
-func executeValidatorsWithContextFlow(ctx context.Context, validators []Interface, input any) (*resultMerger, error) {
-	var merger resultMerger
-	currentCtx := ctx
-
-	for i, validator := range validators {
-		// Update context with accumulated array results for context flow
-		validationCtx := currentCtx
-		if merger.ArrayResult() != nil {
-			if evalItems := merger.ArrayResult().EvaluatedItems(); len(evalItems) > 0 {
-				validationCtx = withEvaluatedItems(currentCtx, evalItems)
-			}
-		}
-
-		result, err := validator.Validate(validationCtx, input)
-		if err != nil {
-			return nil, fmt.Errorf(`validator #%d failed: %w`, i, err)
-		}
-
 		merger.mergeResult(result)
 	}
 


### PR DESCRIPTION
- Fix `unevaluatedItems`/`unevaluatedProperties` incorrectly seeing items evaluated by a *cousin* `allOf` branch (official suite: "unevaluatedItems can't see inside cousins", expected invalid, previously passed)
- `allOf` now isolates each branch and merges annotations upward via `executeValidatorsAndMergeResults`, instead of `executeValidatorsWithContextFlow` which leaked evaluated-items sideways into later branches (it already withheld properties — items were the inconsistency)
- Remove the now-unused `executeValidatorsWithContextFlow` and `withEvaluatedItems` (sole producer of evaluated-items-in-context)
- Parent-level `unevaluatedItems` over an `allOf` is unaffected: it still sees the branches' annotations through the upward result merge
- Verified against the official 2020-12 suite: the cousins case now passes, no other cases regress
