### PR TITLE
fix empty enum to reject all values

### DIFF
--- a/validator/enum_const_test.go
+++ b/validator/enum_const_test.go
@@ -742,3 +742,19 @@ func TestConstValidationComprehensive(t *testing.T) {
 		}
 	})
 }
+
+// TestEmptyEnum verifies that an empty enum ("enum": []) rejects every value,
+// as required by JSON Schema 2020-12. An empty enum is a present constraint
+// matching nothing, not the absence of a constraint.
+func TestEmptyEnum(t *testing.T) {
+	var s schema.Schema
+	require.NoError(t, s.UnmarshalJSON([]byte(`{"enum": []}`)))
+
+	v, err := validator.Compile(context.Background(), &s)
+	require.NoError(t, err)
+
+	for _, value := range []any{"foo", 42, nil, map[string]any{}, []any{}, false} {
+		_, err := v.Validate(context.Background(), value)
+		require.Error(t, err, "empty enum must reject %#v", value)
+	}
+}

--- a/validator/untyped.go
+++ b/validator/untyped.go
@@ -14,6 +14,7 @@ var _ Interface = (*untypedValidator)(nil)
 // untypedValidator handles enum and const validation for schemas without specific types
 type untypedValidator struct {
 	enum          []any
+	hasEnum       bool // Distinguishes an empty enum (rejects all) from no enum constraint
 	constantValue *any // Pointer distinguishes nil vs no const
 }
 
@@ -34,6 +35,7 @@ func (b *UntypedValidatorBuilder) Enum(values ...any) *UntypedValidatorBuilder {
 	}
 	b.v.enum = make([]any, len(values))
 	copy(b.v.enum, values)
+	b.v.hasEnum = true
 	return b
 }
 
@@ -89,8 +91,9 @@ func (u *untypedValidator) Validate(ctx context.Context, value any) (Result, err
 		return nil, nil
 	}
 
-	// Check enum
-	if len(u.enum) > 0 {
+	// Check enum. An empty enum is a valid constraint that rejects every value,
+	// so gate on whether enum was set rather than on its length.
+	if u.hasEnum {
 		if err := validateEnum(ctx, value, u.enum); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- empty enum (`"enum": []`) now rejects all values per JSON Schema 2020-12
- gate enum validation on presence, not length, so empty != absent
- add `TestEmptyEnum` regression test
