### PR TITLE
support data-bounded recursive $ref

### DIFF
--- a/internal/schemactx/context.go
+++ b/internal/schemactx/context.go
@@ -100,6 +100,8 @@ type ValidationContext struct {
 	DynamicScope   []any
 	VocabularySet  any
 	ReferenceStack []string
+	RefDepths      map[string]int // data depth at which each active reference was entered
+	DataDepth      int            // number of child-applying keyword boundaries crossed during compilation
 	Evaluation     *EvaluationContext
 }
 
@@ -247,6 +249,33 @@ func ReferenceStackFromContext(ctx context.Context, dst any) error {
 		return fmt.Errorf("reference stack not found in context")
 	}
 	return blackmagic.AssignIfCompatible(dst, vctx.ReferenceStack)
+}
+
+// WithRefDepths stores the per-reference data-depth map used to distinguish
+// pure reference cycles from data-bounded recursion.
+func WithRefDepths(ctx context.Context, depths map[string]int) context.Context {
+	vctx := ValidationContextFrom(ctx)
+	newVctx := *vctx // copy
+	newVctx.RefDepths = depths
+	return WithValidationContext(ctx, &newVctx)
+}
+
+// RefDepthsFromContext returns the per-reference data-depth map (nil if absent).
+func RefDepthsFromContext(ctx context.Context) map[string]int {
+	return ValidationContextFrom(ctx).RefDepths
+}
+
+// WithDataDepth sets the count of child-applying keyword boundaries crossed so far.
+func WithDataDepth(ctx context.Context, depth int) context.Context {
+	vctx := ValidationContextFrom(ctx)
+	newVctx := *vctx // copy
+	newVctx.DataDepth = depth
+	return WithValidationContext(ctx, &newVctx)
+}
+
+// DataDepthFromContext returns the current data depth (0 if absent).
+func DataDepthFromContext(ctx context.Context) int {
+	return ValidationContextFrom(ctx).DataDepth
 }
 
 // WithEvaluationContext adds evaluation context to the context

--- a/schema.go
+++ b/schema.go
@@ -312,6 +312,26 @@ func ReferenceStackFromContext(ctx context.Context) []string {
 	return stack
 }
 
+// WithRefDepths stores the per-reference data-depth map for cycle classification.
+func WithRefDepths(ctx context.Context, depths map[string]int) context.Context {
+	return schemactx.WithRefDepths(ctx, depths)
+}
+
+// RefDepthsFromContext returns the per-reference data-depth map (nil if absent).
+func RefDepthsFromContext(ctx context.Context) map[string]int {
+	return schemactx.RefDepthsFromContext(ctx)
+}
+
+// WithDataDepth sets the number of child-applying keyword boundaries crossed during compilation.
+func WithDataDepth(ctx context.Context, depth int) context.Context {
+	return schemactx.WithDataDepth(ctx, depth)
+}
+
+// DataDepthFromContext returns the current compilation data depth (0 if absent).
+func DataDepthFromContext(ctx context.Context) int {
+	return schemactx.DataDepthFromContext(ctx)
+}
+
 // Context keys for validator-specific data
 type dependentSchemasKey struct{}
 

--- a/validator/array.go
+++ b/validator/array.go
@@ -14,6 +14,10 @@ var _ Builder = (*ArrayValidatorBuilder)(nil)
 var _ Interface = (*arrayValidator)(nil)
 
 func compileArrayValidator(ctx context.Context, s *schema.Schema, strictType bool) (Interface, error) {
+	// Array keywords (prefixItems, items, contains) apply their subschemas to
+	// child elements, so crossing into them is a data boundary for recursion
+	// classification.
+	ctx = schema.WithDataDepth(ctx, schema.DataDepthFromContext(ctx)+1)
 	v := Array()
 
 	if s.HasMinItems() && vocabulary.IsKeywordEnabledInContext(ctx, "minItems") {

--- a/validator/compiler.go
+++ b/validator/compiler.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 
 	schema "github.com/lestrrat-go/json-schema"
@@ -137,20 +138,36 @@ func Compile(ctx context.Context, s *schema.Schema) (Interface, error) {
 		// Get root schema from context (guaranteed to be present)
 		_ = schema.RootSchemaFromContext(ctx)
 
-		// Check for circular references by looking at context
-		if stack := schema.ReferenceStackFromContext(ctx); stack != nil {
-			if slices.Contains(stack, reference) {
-				return nil, fmt.Errorf("circular reference detected: %s", reference)
+		// Circular-reference handling. A reference already on the stack is a
+		// cycle. If a data boundary (an object/array child-applying keyword) has
+		// been crossed since it was entered, it is data-bounded recursion that
+		// terminates on the instance being validated, so compile it lazily as a
+		// ReferenceValidator. Otherwise it is a pure cycle that can never
+		// terminate, which is a compile-time error.
+		curDepth := schema.DataDepthFromContext(ctx)
+		refDepths := schema.RefDepthsFromContext(ctx)
+		stack := schema.ReferenceStackFromContext(ctx)
+		if slices.Contains(stack, reference) {
+			if curDepth > refDepths[reference] {
+				return &ReferenceValidator{
+					reference:  reference,
+					resolver:   resolver,
+					rootSchema: schema.RootSchemaFromContext(ctx),
+					baseSchema: schema.BaseSchemaFromContext(ctx),
+					baseURI:    schema.BaseURIFromContext(ctx),
+				}, nil
 			}
-			// Add current reference to stack
-			newStack := make([]string, len(stack)+1)
-			copy(newStack, stack)
-			newStack[len(stack)] = reference
-			ctx = schema.WithReferenceStack(ctx, newStack)
-		} else {
-			// Start new reference stack
-			ctx = schema.WithReferenceStack(ctx, []string{reference})
+			return nil, fmt.Errorf("circular reference detected: %s", reference)
 		}
+		// Push the reference, recording the data depth at which it was entered.
+		newStack := make([]string, len(stack)+1)
+		copy(newStack, stack)
+		newStack[len(stack)] = reference
+		ctx = schema.WithReferenceStack(ctx, newStack)
+		newDepths := make(map[string]int, len(refDepths)+1)
+		maps.Copy(newDepths, refDepths)
+		newDepths[reference] = curDepth
+		ctx = schema.WithRefDepths(ctx, newDepths)
 
 		// Resolve the reference to get the target schema
 		var targetSchema schema.Schema

--- a/validator/object.go
+++ b/validator/object.go
@@ -16,6 +16,10 @@ var _ Builder = (*ObjectValidatorBuilder)(nil)
 var _ Interface = (*objectValidator)(nil)
 
 func compileObjectValidator(ctx context.Context, s *schema.Schema, strictType bool) (Interface, error) {
+	// Object keywords (properties, patternProperties, additionalProperties,
+	// propertyNames) apply their subschemas to child values, so crossing into
+	// them is a data boundary for recursion classification.
+	ctx = schema.WithDataDepth(ctx, schema.DataDepthFromContext(ctx)+1)
 	v := Object()
 
 	if s.HasMinProperties() && vocabulary.IsKeywordEnabledInContext(ctx, "minProperties") {

--- a/validator/recursive_ref_test.go
+++ b/validator/recursive_ref_test.go
@@ -1,0 +1,88 @@
+package validator_test
+
+import (
+	"testing"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecursiveReference covers data-bounded recursive $ref: a reference that
+// cycles back through a child-applying keyword terminates on the instance and
+// must compile and validate, whereas a pure $ref cycle (no data consumed) is a
+// compile-time error.
+func TestRecursiveReference(t *testing.T) {
+	compile := func(t *testing.T, jsonSchema string) (validator.Interface, error) {
+		t.Helper()
+		var s schema.Schema
+		require.NoError(t, s.UnmarshalJSON([]byte(jsonSchema)))
+		ctx := schema.WithResolver(t.Context(), schema.NewResolver())
+		ctx = schema.WithRootSchema(ctx, &s)
+		return validator.Compile(ctx, &s)
+	}
+
+	t.Run("self reference via $ref to document root", func(t *testing.T) {
+		// {"$ref":"#"} under properties: recursion bounded by nesting depth.
+		v, err := compile(t, `{
+			"type": "object",
+			"required": ["name"],
+			"properties": {"name": {"type": "string"}, "child": {"$ref": "#"}}
+		}`)
+		require.NoError(t, err)
+
+		_, err = v.Validate(t.Context(), map[string]any{"name": "root"})
+		require.NoError(t, err)
+		_, err = v.Validate(t.Context(), map[string]any{
+			"name":  "root",
+			"child": map[string]any{"name": "kid", "child": map[string]any{"name": "grandkid"}},
+		})
+		require.NoError(t, err)
+		// A nested child missing the required "name" must fail.
+		_, err = v.Validate(t.Context(), map[string]any{
+			"name":  "root",
+			"child": map[string]any{"child": map[string]any{}},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("mutually recursive schemas via $defs", func(t *testing.T) {
+		v, err := compile(t, `{
+			"type": "object",
+			"properties": {
+				"value": {"type": "number"},
+				"next": {"$ref": "#/$defs/node"}
+			},
+			"$defs": {
+				"node": {
+					"type": "object",
+					"properties": {"value": {"type": "number"}, "next": {"$ref": "#"}}
+				}
+			}
+		}`)
+		require.NoError(t, err)
+
+		_, err = v.Validate(t.Context(), map[string]any{
+			"value": 1.0,
+			"next":  map[string]any{"value": 2.0, "next": map[string]any{"value": 3.0}},
+		})
+		require.NoError(t, err)
+		_, err = v.Validate(t.Context(), map[string]any{
+			"value": 1.0,
+			"next":  map[string]any{"value": "not a number"},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("pure $ref cycle is a compile-time error", func(t *testing.T) {
+		_, err := compile(t, `{
+			"$ref": "#/$defs/a",
+			"$defs": {
+				"a": {"$ref": "#/$defs/b"},
+				"b": {"$ref": "#/$defs/a"}
+			}
+		}`)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "circular reference")
+	})
+}

--- a/validator/reference.go
+++ b/validator/reference.go
@@ -16,6 +16,8 @@ type ReferenceValidator struct {
 	resolveErr   error
 	resolver     *schema.Resolver
 	rootSchema   *schema.Schema
+	baseSchema   *schema.Schema // Enclosing resource captured at compile time (nil = use root)
+	baseURI      string         // Enclosing resource's base URI captured at compile time
 }
 
 func (r *ReferenceValidator) Validate(ctx context.Context, v any) (Result, error) {
@@ -64,24 +66,45 @@ func (r *ReferenceValidator) resolveReference(ctx context.Context) (Interface, e
 		ctx = schema.WithReferenceStack(ctx, []string{r.reference})
 	}
 
-	// Resolve the reference to get the target schema
+	// Resolve the reference against the enclosing resource captured at compile
+	// time (falling back to context/root), so deferred recursive references in
+	// a nested $id resource still resolve within that resource.
 	var targetSchema schema.Schema
-	baseURI := schema.BaseURIFromContext(ctx)
+	baseURI := r.baseURI
+	if baseURI == "" {
+		baseURI = schema.BaseURIFromContext(ctx)
+	}
 	refCtx := ctx
 	if baseURI != "" {
 		refCtx = schema.WithBaseURI(ctx, baseURI)
 	}
-	// Add base schema context for reference resolution
-	if rootSchema := schema.RootSchemaFromContext(ctx); rootSchema != nil {
-		refCtx = schema.WithBaseSchema(refCtx, rootSchema)
+	baseSchema := r.baseSchema
+	if baseSchema == nil {
+		baseSchema = schema.BaseSchemaFromContext(ctx)
+	}
+	if baseSchema == nil {
+		baseSchema = rootSchema
+	}
+	if baseSchema != nil {
+		refCtx = schema.WithBaseSchema(refCtx, baseSchema)
 	}
 	if err := resolver.ResolveReference(refCtx, &targetSchema, r.reference); err != nil {
 		return nil, fmt.Errorf("failed to resolve reference %s: %w", r.reference, err)
 	}
 
-	// Compile the resolved schema into a validator
-	// IMPORTANT: Keep the original root schema context to ensure nested references can be resolved
-	return Compile(ctx, &targetSchema)
+	// Compile the resolved schema. Seed the resolver (carrying the in-document
+	// $id registry), root schema, and base schema/URI: this runs at validation
+	// time, when the incoming context generally lacks them, and without the
+	// resolver nested references would fall back to external retrieval.
+	compileCtx := schema.WithResolver(ctx, resolver)
+	compileCtx = schema.WithRootSchema(compileCtx, rootSchema)
+	if baseURI != "" {
+		compileCtx = schema.WithBaseURI(compileCtx, baseURI)
+	}
+	if baseSchema != nil {
+		compileCtx = schema.WithBaseSchema(compileCtx, baseSchema)
+	}
+	return Compile(compileCtx, &targetSchema)
 }
 
 // DynamicReferenceValidator handles $dynamicRef with proper dynamic scope resolution


### PR DESCRIPTION
- compile data-bounded recursive `$ref` lazily instead of erroring; pure cycles still error at compile
- track compile-time `dataDepth`; at the circular guard, defer to a lazy `ReferenceValidator` when a child-applying keyword boundary was crossed, else error
- deferred validators capture resolver/root/base so nested refs resolve at validate time
- spec-suite skips 38 → 34 (`ref.json` 17 → 0); no hard failures
- add `validator/recursive_ref_test.go` (self-ref, mutual recursion, pure-cycle error)
