### PR TITLE
resolve $dynamicRef via runtime dynamic scope

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -31,16 +31,7 @@ func newResourceIndex() *resourceIndex {
 // with its own $id re-bases the subtree beneath it (resolved against the
 // enclosing base per RFC 3986), which is how nested/bundled resources are made
 // addressable by their canonical absolute URIs.
-//
-// When allowNestedIDs is false, nested resources (subschemas with their own
-// $id) are left unregistered and unwalked. This deliberately preserves the
-// pre-registry resolution behavior for documents that use $dynamicRef /
-// $dynamicAnchor: correct $dynamicRef resolution requires runtime dynamic-scope
-// tracking that is not yet implemented, so making such documents newly
-// resolvable would yield incorrect results rather than the prior (conservative)
-// resolution failure. The document's own root $id and root-scope anchors are
-// still registered.
-func (idx *resourceIndex) index(s *Schema, baseURI string, visited map[*Schema]struct{}, allowNestedIDs bool) {
+func (idx *resourceIndex) index(s *Schema, baseURI string, visited map[*Schema]struct{}) {
 	if s == nil {
 		return
 	}
@@ -64,34 +55,29 @@ func (idx *resourceIndex) index(s *Schema, baseURI string, visited map[*Schema]s
 	}
 
 	for _, child := range childSchemas(s) {
-		if !allowNestedIDs && child.HasID() && child.ID() != "" {
-			continue
-		}
-		idx.index(child, current, visited, allowNestedIDs)
+		idx.index(child, current, visited)
 	}
 }
 
-// usesDynamicReferences reports whether any schema in the tree declares a
-// $dynamicAnchor or $dynamicRef, indicating the document relies on dynamic-scope
-// resolution.
-func usesDynamicReferences(s *Schema, visited map[*Schema]struct{}) bool {
-	if s == nil {
-		return false
+// FindDynamicAnchor searches a schema resource for a subschema declaring
+// $dynamicAnchor == name, without crossing into nested $id resources (which are
+// distinct resources with their own dynamic scope). It returns nil if not found.
+func FindDynamicAnchor(resource *Schema, name string) *Schema {
+	if resource == nil {
+		return nil
 	}
-	if _, seen := visited[s]; seen {
-		return false
+	if resource.HasDynamicAnchor() && resource.DynamicAnchor() == name {
+		return resource
 	}
-	visited[s] = struct{}{}
-
-	if s.HasDynamicAnchor() || s.HasDynamicReference() {
-		return true
-	}
-	for _, child := range childSchemas(s) {
-		if usesDynamicReferences(child, visited) {
-			return true
+	for _, child := range childSchemas(resource) {
+		if child.HasID() && child.ID() != "" {
+			continue // a nested $id starts a separate resource
+		}
+		if found := FindDynamicAnchor(child, name); found != nil {
+			return found
 		}
 	}
-	return false
+	return nil
 }
 
 // childSchemas returns the immediate subschemas of s across every keyword that

--- a/resolver.go
+++ b/resolver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/lestrrat-go/json-schema/internal/schemactx"
 	"github.com/lestrrat-go/jsref/v2"
@@ -16,6 +17,9 @@ import (
 type Resolver struct {
 	resolver *jsref.StackedResolver
 	index    *resourceIndex
+
+	mu         sync.Mutex
+	registered map[*Schema]struct{} // roots already indexed, to avoid re-indexing
 }
 
 // NewResolver creates a new schema resolver with in-document, HTTP and
@@ -53,12 +57,38 @@ func (r *Resolver) RegisterRoot(root *Schema) {
 	if r.index == nil || root == nil {
 		return
 	}
+	// Index each root at most once. Compilation happens before validation, so
+	// once indexed there are no further writes to the index; this also prevents
+	// a data race where validation-time compilation of a target that happens to
+	// be the root would re-index concurrently with registry lookups.
+	r.mu.Lock()
+	if r.registered == nil {
+		r.registered = make(map[*Schema]struct{})
+	}
+	if _, done := r.registered[root]; done {
+		r.mu.Unlock()
+		return
+	}
+	r.registered[root] = struct{}{}
 	base := ""
 	if root.HasID() && root.ID() != "" {
 		base, _, _ = splitFragment(root.ID())
 	}
-	allowNestedIDs := !usesDynamicReferences(root, make(map[*Schema]struct{}))
-	r.index.index(root, base, make(map[*Schema]struct{}), allowNestedIDs)
+	r.index.index(root, base, make(map[*Schema]struct{}))
+	r.mu.Unlock()
+}
+
+// ResourceFor returns the schema resource registered under the given absolute
+// base URI (no fragment), or nil if none. It lets reference resolution record
+// which resource an instance enters for $dynamicRef dynamic-scope tracking.
+func (r *Resolver) ResourceFor(uri string) *Schema {
+	if r.index == nil || uri == "" {
+		return nil
+	}
+	base, _, _ := splitFragment(uri)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.index.byURI[base]
 }
 
 // ResolveJSONReference resolves JSON pointer references against a base schema from context.

--- a/validator/compiler.go
+++ b/validator/compiler.go
@@ -11,9 +11,56 @@ import (
 	"github.com/lestrrat-go/json-schema/vocabulary"
 )
 
-// Compile implements the new simplified compilation approach using UnevaluatedCoordinator.
-// This replaces the complex old compilation logic.
+// Compile builds a validator for s. A schema that declares a $dynamicAnchor is
+// a potential bookend target for $dynamicRef, so its validator is wrapped to
+// push the schema onto the runtime dynamic scope when validation enters it.
 func Compile(ctx context.Context, s *schema.Schema) (Interface, error) {
+	v, err := compileSchema(ctx, s)
+	if err != nil {
+		return nil, err
+	}
+	// A schema resource (one bearing $id) or any schema declaring a
+	// $dynamicAnchor participates in the dynamic scope: wrap it so entering it
+	// during validation records it, letting $dynamicRef find the outermost
+	// in-scope $dynamicAnchor.
+	if s != nil && (s.HasID() || s.HasDynamicAnchor()) {
+		return &dynamicScopeValidator{schema: s, inner: v}, nil
+	}
+	return v, nil
+}
+
+// combineReferenceWithConstraints combines a resolved $ref/$dynamicRef validator
+// with any sibling keywords present on the same schema, mirroring $ref handling
+// so that keywords like unevaluatedProperties alongside a $dynamicRef are still
+// applied (and can see the reference target's annotations).
+func combineReferenceWithConstraints(ctx context.Context, s *schema.Schema, resolvedValidator Interface) (Interface, error) {
+	if !hasOtherConstraints(s) {
+		return resolvedValidator, nil
+	}
+	schemaWithoutRef := createSchemaWithoutRef(s)
+	if schemaWithoutRef.HasUnevaluatedProperties() || schemaWithoutRef.HasUnevaluatedItems() {
+		schemaWithoutUnevaluated := createSchemaWithoutUnevaluatedFields(schemaWithoutRef)
+		additionalValidator, err := Compile(ctx, schemaWithoutUnevaluated)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile additional constraints: %w", err)
+		}
+		return &unevaluatedCoordinator{
+			validators:       []Interface{resolvedValidator, additionalValidator},
+			unevaluatedProps: schemaWithoutRef.UnevaluatedProperties(),
+			unevaluatedItems: schemaWithoutRef.UnevaluatedItems(),
+			strictArrayType:  hasExplicitArrayType(schemaWithoutRef),
+			strictObjectType: hasExplicitObjectType(schemaWithoutRef),
+		}, nil
+	}
+	additionalValidator, err := Compile(ctx, schemaWithoutRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile additional constraints: %w", err)
+	}
+	return AllOf(resolvedValidator, additionalValidator), nil
+}
+
+// compileSchema implements the simplified compilation approach using UnevaluatedCoordinator.
+func compileSchema(ctx context.Context, s *schema.Schema) (Interface, error) {
 	// Set up context with default resolver if none provided
 	if schema.ResolverFromContext(ctx) == nil {
 		ctx = schema.WithResolver(ctx, schema.NewResolver())
@@ -110,26 +157,26 @@ func Compile(ctx context.Context, s *schema.Schema) (Interface, error) {
 	}
 
 	if reference != "" {
-		// Handle $dynamicRef with proper DynamicReferenceValidator
+		// Handle $dynamicRef with a DynamicReferenceValidator. Capture the
+		// enclosing resource's base schema and base URI (not just the document
+		// root) so the non-dynamic fallback — a $dynamicRef whose fragment is a
+		// JSON pointer or a plain $ref to an $anchor — resolves within the correct
+		// schema resource. The dynamic scope itself is read at validation time.
 		if isDynamicRef {
-			// Create dynamic reference validator with stored context. Capture the
-			// enclosing resource's base schema and base URI (not just the document
-			// root) so that the non-dynamic fallback — a $dynamicRef whose fragment
-			// is a JSON pointer or a plain $ref to an $anchor — resolves within the
-			// correct schema resource when nested $id re-basing is in effect.
-			dynamicScope := schema.DynamicScopeFromContext(ctx)
 			baseSchema := schema.BaseSchemaFromContext(ctx)
 			if baseSchema == nil {
 				baseSchema = schema.RootSchemaFromContext(ctx)
 			}
-			return &DynamicReferenceValidator{
-				reference:    reference,
-				resolver:     schema.ResolverFromContext(ctx),
-				rootSchema:   schema.RootSchemaFromContext(ctx),
-				baseSchema:   baseSchema,
-				baseURI:      schema.BaseURIFromContext(ctx),
-				dynamicScope: dynamicScope,
-			}, nil
+			drv := &DynamicReferenceValidator{
+				reference:  reference,
+				resolver:   schema.ResolverFromContext(ctx),
+				rootSchema: schema.RootSchemaFromContext(ctx),
+				baseSchema: baseSchema,
+				baseURI:    schema.BaseURIFromContext(ctx),
+			}
+			// Combine with any sibling keywords (e.g. unevaluatedProperties), the
+			// same way $ref does, so they are not silently dropped.
+			return combineReferenceWithConstraints(ctx, s, drv)
 		}
 
 		// Get resolver from context (guaranteed to be present)
@@ -239,7 +286,16 @@ func Compile(ctx context.Context, s *schema.Schema) (Interface, error) {
 		if targetSchema.HasID() {
 			resolvedCtx = schema.WithBaseSchema(ctx, &targetSchema)
 		}
-		return Compile(resolvedCtx, &targetSchema)
+		compiled, err := Compile(resolvedCtx, &targetSchema)
+		if err != nil {
+			return nil, err
+		}
+		// Following the $ref enters the target's resource; record it on the
+		// dynamic scope so a $dynamicRef deeper in the target can find it.
+		if resource := resolver.ResourceFor(schema.ResolveURI(baseURI, reference)); resource != nil && resource != &targetSchema {
+			compiled = &dynamicScopeValidator{schema: resource, inner: compiled}
+		}
+		return compiled, nil
 	}
 	var validators []Interface
 

--- a/validator/dynamic_scope_test.go
+++ b/validator/dynamic_scope_test.go
@@ -1,0 +1,81 @@
+package validator_test
+
+import (
+	"testing"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDynamicRefRuntimeScope covers $dynamicRef resolution that depends on the
+// runtime dynamic scope (the resources actually entered while validating the
+// instance), including the bookending requirement.
+func TestDynamicRefRuntimeScope(t *testing.T) {
+	compile := func(t *testing.T, jsonSchema string) validator.Interface {
+		t.Helper()
+		var s schema.Schema
+		require.NoError(t, s.UnmarshalJSON([]byte(jsonSchema)))
+		ctx := schema.WithResolver(t.Context(), schema.NewResolver())
+		ctx = schema.WithRootSchema(ctx, &s)
+		v, err := validator.Compile(ctx, &s)
+		require.NoError(t, err)
+		return v
+	}
+
+	t.Run("resolves to outermost $dynamicAnchor in scope", func(t *testing.T) {
+		// items' $dynamicRef "#items" must resolve to the root resource's
+		// $dynamicAnchor (string), not list's placeholder, so the array must
+		// contain strings.
+		v := compile(t, `{
+			"$id": "https://example.com/dynscope/root",
+			"$ref": "list",
+			"$defs": {
+				"foo": {"$dynamicAnchor": "items", "type": "string"},
+				"list": {
+					"$id": "list",
+					"type": "array",
+					"items": {"$dynamicRef": "#items"},
+					"$defs": {"items": {"$dynamicAnchor": "items"}}
+				}
+			}
+		}`)
+
+		_, err := v.Validate(t.Context(), []any{"a", "b"})
+		require.NoError(t, err)
+		_, err = v.Validate(t.Context(), []any{"a", 1})
+		require.Error(t, err, "non-string item must fail the root's string $dynamicAnchor")
+	})
+
+	t.Run("no bookend behaves like a normal $ref", func(t *testing.T) {
+		// extended has a static $anchor (not $dynamicAnchor) named meta, so the
+		// $dynamicRef must NOT walk the dynamic scope to the root; baz validates
+		// against extended (permissive), not root (foo const "pass").
+		v := compile(t, `{
+			"$id": "https://example.com/nobookend/derived",
+			"$dynamicAnchor": "meta",
+			"type": "object",
+			"properties": {"foo": {"const": "pass"}},
+			"$ref": "extended",
+			"$defs": {
+				"extended": {
+					"$id": "extended",
+					"$anchor": "meta",
+					"type": "object",
+					"properties": {"bar": {"$ref": "bar"}}
+				},
+				"bar": {
+					"$id": "bar",
+					"type": "object",
+					"properties": {"baz": {"$dynamicRef": "extended#meta"}}
+				}
+			}
+		}`)
+
+		_, err := v.Validate(t.Context(), map[string]any{
+			"foo": "pass",
+			"bar": map[string]any{"baz": map[string]any{"foo": "anything"}},
+		})
+		require.NoError(t, err)
+	})
+}

--- a/validator/generator.go
+++ b/validator/generator.go
@@ -356,23 +356,9 @@ func (g *codeGenerator) generateDynamicReference(dst io.Writer, v *DynamicRefere
 	var buf bytes.Buffer
 	o := codegen.NewOutput(&buf)
 
-	// If the dynamic reference has been resolved, generate the resolved validator
-	if v.resolved != nil {
-		// Generate the resolved validator, but watch out for circular references
-		if v.resolved == v {
-			// Self-reference - create EmptyValidator to avoid infinite recursion
-			o.R("&validator.EmptyValidator{}")
-		} else {
-			if err := g.Generate(&buf, v.resolved); err != nil {
-				// If we can't generate the resolved validator, fall back to EmptyValidator
-				o.R("&validator.EmptyValidator{}")
-			}
-		}
-	} else {
-		// For unresolved dynamic references, create a runtime-resolved validator
-		// This preserves the dynamic resolution behavior while generating valid code
-		o.R("validator.NewDynamicReferenceValidator(%q)", v.reference)
-	}
+	// $dynamicRef resolves against the runtime dynamic scope, which differs per
+	// validation, so always emit a runtime-resolved validator.
+	o.R("validator.NewDynamicReferenceValidator(%q)", v.reference)
 
 	_, err := buf.WriteTo(dst)
 	return err

--- a/validator/reference.go
+++ b/validator/reference.go
@@ -104,20 +104,46 @@ func (r *ReferenceValidator) resolveReference(ctx context.Context) (Interface, e
 	if baseSchema != nil {
 		compileCtx = schema.WithBaseSchema(compileCtx, baseSchema)
 	}
-	return Compile(compileCtx, &targetSchema)
+	compiled, err := Compile(compileCtx, &targetSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	// Following a $ref into another resource enters that resource's dynamic
+	// scope, even when the reference targets a subschema within it. Push the
+	// enclosing resource so $dynamicRef bookending sees it.
+	if resource := resolver.ResourceFor(schema.ResolveURI(baseURI, r.reference)); resource != nil && resource != &targetSchema {
+		compiled = &dynamicScopeValidator{schema: resource, inner: compiled}
+	}
+	return compiled, nil
 }
 
-// DynamicReferenceValidator handles $dynamicRef with proper dynamic scope resolution
+// dynamicScopeValidator pushes its schema resource onto the runtime dynamic
+// scope before delegating to the wrapped validator. Validation thus accumulates
+// the chain of $dynamicAnchor-bearing resources actually entered along the
+// instance's evaluation path, which is what $dynamicRef bookending consults.
+type dynamicScopeValidator struct {
+	schema *schema.Schema
+	inner  Interface
+}
+
+func (d *dynamicScopeValidator) Validate(ctx context.Context, v any) (Result, error) {
+	ctx = schema.WithDynamicScope(ctx, d.schema)
+	return d.inner.Validate(ctx, v)
+}
+
+// DynamicReferenceValidator handles $dynamicRef. Unlike $ref, a $dynamicRef can
+// resolve to different targets on different validations depending on the runtime
+// dynamic scope, so resolution happens per-Validate (not memoized once).
 type DynamicReferenceValidator struct {
-	reference    string
-	resolvedOnce sync.Once
-	resolved     Interface
-	resolveErr   error
-	resolver     *schema.Resolver
-	rootSchema   *schema.Schema
-	baseSchema   *schema.Schema   // Enclosing resource for non-dynamic fallback resolution
-	baseURI      string           // Enclosing resource's base URI
-	dynamicScope []*schema.Schema // Store the dynamic scope chain from compilation
+	reference  string
+	resolver   *schema.Resolver
+	rootSchema *schema.Schema
+	baseSchema *schema.Schema // Enclosing resource for non-dynamic fallback resolution
+	baseURI    string         // Enclosing resource's base URI
+
+	mu    sync.Mutex
+	cache map[*schema.Schema]Interface // compiled validators keyed by resolved target
 }
 
 // NewDynamicReferenceValidator creates a new DynamicReferenceValidator for the given reference
@@ -128,172 +154,143 @@ func NewDynamicReferenceValidator(reference string) *DynamicReferenceValidator {
 }
 
 func (dr *DynamicReferenceValidator) Validate(ctx context.Context, v any) (Result, error) {
-	// Lazy resolution - only resolve when actually needed for validation
-	dr.resolvedOnce.Do(func() {
-		dr.resolved, dr.resolveErr = dr.resolveDynamicReference(ctx)
-	})
-
-	if dr.resolveErr != nil {
-		return nil, fmt.Errorf("dynamic reference resolution failed for %s: %w", dr.reference, dr.resolveErr)
+	target, err := dr.resolveTarget(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dynamic reference resolution failed for %s: %w", dr.reference, err)
 	}
-
-	return dr.resolved.Validate(ctx, v)
+	validator, err := dr.validatorFor(ctx, target)
+	if err != nil {
+		return nil, fmt.Errorf("dynamic reference resolution failed for %s: %w", dr.reference, err)
+	}
+	return validator.Validate(ctx, v)
 }
 
-func (dr *DynamicReferenceValidator) resolveDynamicReference(ctx context.Context) (Interface, error) {
-	// Use stored resolver and root schema from compilation time
+// resolveTarget resolves the $dynamicRef against the current runtime dynamic
+// scope carried in ctx.
+func (dr *DynamicReferenceValidator) resolveTarget(ctx context.Context) (*schema.Schema, error) {
 	resolver := dr.resolver
 	if resolver == nil {
-		resolver = schema.NewResolver()
-	}
-
-	rootSchema := dr.rootSchema
-	if rootSchema == nil {
-		return nil, fmt.Errorf("no root schema available for dynamic reference resolution: %s", dr.reference)
-	}
-
-	// Create context with stored dynamic scope chain from compilation time
-	ctxWithScope := ctx
-	if dr.dynamicScope != nil {
-		// Build context with all scope elements at once to avoid nested context in loop
-		//nolint:fatcontext // Intentional: building dynamic scope chain requires nested contexts
-		for _, scope := range dr.dynamicScope {
-			ctxWithScope = schema.WithDynamicScope(ctxWithScope, scope)
+		if resolver = schema.ResolverFromContext(ctx); resolver == nil {
+			resolver = schema.NewResolver()
 		}
 	}
-
-	// Check for circular references by looking at context
-	if stack := schema.ReferenceStackFromContext(ctxWithScope); stack != nil {
-		if slices.Contains(stack, dr.reference) {
-			return nil, fmt.Errorf("circular reference detected: %s", dr.reference)
-		}
-		// Add current reference to stack
-		newStack := make([]string, len(stack)+1)
-		copy(newStack, stack)
-		newStack[len(stack)] = dr.reference
-		ctxWithScope = schema.WithReferenceStack(ctxWithScope, newStack)
-	} else {
-		// Start new reference stack
-		ctxWithScope = schema.WithReferenceStack(ctxWithScope, []string{dr.reference})
-	}
-
-	// Resolve the $dynamicRef using stored dynamic scope chain. The non-dynamic
-	// fallback resolves against the enclosing resource (baseSchema/baseURI)
-	// captured at compile time, falling back to the document root.
 	baseSchema := dr.baseSchema
 	if baseSchema == nil {
-		baseSchema = rootSchema
+		baseSchema = schema.BaseSchemaFromContext(ctx)
 	}
+	if baseSchema == nil {
+		baseSchema = dr.rootSchema
+	}
+	if baseSchema == nil {
+		baseSchema = schema.RootSchemaFromContext(ctx)
+	}
+
+	refCtx := ctx
 	if dr.baseURI != "" {
-		ctxWithScope = schema.WithBaseURI(ctxWithScope, dr.baseURI)
+		refCtx = schema.WithBaseURI(refCtx, dr.baseURI)
 	}
-	targetSchema, err := resolveDynamicRef(ctxWithScope, resolver, baseSchema, dr.reference)
+	if baseSchema != nil {
+		refCtx = schema.WithBaseSchema(refCtx, baseSchema)
+	}
+	return resolveDynamicRef(refCtx, resolver, baseSchema, dr.reference)
+}
+
+// validatorFor compiles (and caches) the validator for a resolved target schema.
+func (dr *DynamicReferenceValidator) validatorFor(ctx context.Context, target *schema.Schema) (Interface, error) {
+	dr.mu.Lock()
+	if dr.cache == nil {
+		dr.cache = make(map[*schema.Schema]Interface)
+	}
+	if v, ok := dr.cache[target]; ok {
+		dr.mu.Unlock()
+		return v, nil
+	}
+	dr.mu.Unlock()
+
+	resolver := dr.resolver
+	if resolver == nil {
+		resolver = schema.ResolverFromContext(ctx)
+	}
+	root := dr.rootSchema
+	if root == nil {
+		root = schema.RootSchemaFromContext(ctx)
+	}
+	compileCtx := ctx
+	if resolver != nil {
+		compileCtx = schema.WithResolver(compileCtx, resolver)
+	}
+	if root != nil {
+		compileCtx = schema.WithRootSchema(compileCtx, root)
+	}
+	if target.HasID() && target.ID() != "" {
+		// Resolve the target's (possibly relative) $id against the base URI under
+		// which the $dynamicRef itself was resolved, so the target's own relative
+		// references resolve within its resource.
+		parentBase := dr.baseURI
+		if parentBase == "" {
+			parentBase = schema.BaseURIFromContext(ctx)
+		}
+		if base := schema.ResolveURI(parentBase, target.ID()); base != "" {
+			compileCtx = schema.WithBaseURI(compileCtx, base)
+		}
+		compileCtx = schema.WithBaseSchema(compileCtx, target)
+	}
+
+	v, err := Compile(compileCtx, target)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve dynamic reference %s: %w", dr.reference, err)
+		return nil, fmt.Errorf("failed to compile dynamic reference target %s: %w", dr.reference, err)
 	}
 
-	// If the target schema has relative references, we need to ensure they're resolved
-	// against the correct base URI. For metaschema, this is crucial.
-	if targetSchema.HasID() && targetSchema.ID() != "" {
-		// Set the base URI from the target schema's $id
-		if baseURI := extractBaseURI(targetSchema.ID()); baseURI != "" {
-			ctxWithScope = schema.WithBaseURI(ctxWithScope, baseURI)
-		}
-	}
-
-	// Compile the resolved target schema
-	return Compile(ctxWithScope, targetSchema)
+	dr.mu.Lock()
+	dr.cache[target] = v
+	dr.mu.Unlock()
+	return v, nil
 }
 
-// extractBaseURI extracts the base URI from a reference for context resolution
-func extractBaseURI(reference string) string {
-	// Handle absolute URIs
-	if strings.HasPrefix(reference, "http://") || strings.HasPrefix(reference, "https://") {
-		// Split on '#' to get the URI part without fragment
-		parts := strings.Split(reference, "#")
-		uri := parts[0]
-
-		// Find the last '/' to get the directory path
-		lastSlash := strings.LastIndex(uri, "/")
-		if lastSlash != -1 {
-			return uri[:lastSlash+1] // Include the trailing slash
-		}
-		return uri + "/" // Add trailing slash if not present
-	}
-
-	// For relative references, we can't determine base URI without context
-	return ""
-}
-
-// resolveDynamicRef resolves a $dynamicRef by looking up the dynamic scope chain
-// for the nearest schema with a matching $dynamicAnchor
+// resolveDynamicRef resolves a $dynamicRef. It first resolves the reference the
+// way $ref would (the "lexical" target). When the reference's fragment is a
+// plain anchor (e.g. "#meta" or "extended#meta") and that lexical target itself
+// declares a $dynamicAnchor of the same name — the bookending requirement — the
+// reference instead resolves to the same $dynamicAnchor in the FIRST (outermost)
+// resource of the runtime dynamic scope. Otherwise it behaves exactly like $ref.
 func resolveDynamicRef(ctx context.Context, resolver *schema.Resolver, baseSchema *schema.Schema, dynamicRef string) (*schema.Schema, error) {
-	// Parse the dynamic reference - it should be in the form "#anchorName"
-	if !strings.HasPrefix(dynamicRef, "#") {
-		// For non-anchor dynamic refs, treat as normal reference
-		var targetSchema schema.Schema
-		baseURI := schema.BaseURIFromContext(ctx)
-		refCtx := schema.WithBaseSchema(ctx, baseSchema)
-		if baseURI != "" {
-			refCtx = schema.WithBaseURI(refCtx, baseURI)
-		}
-		if err := resolver.ResolveReference(refCtx, &targetSchema, dynamicRef); err != nil {
-			return nil, fmt.Errorf("failed to resolve dynamic reference %s: %w", dynamicRef, err)
-		}
-		return &targetSchema, nil
+	baseURI := schema.BaseURIFromContext(ctx)
+	refCtx := schema.WithBaseSchema(ctx, baseSchema)
+	if baseURI != "" {
+		refCtx = schema.WithBaseURI(refCtx, baseURI)
 	}
 
-	// Check if this is a JSON pointer reference (starts with #/)
-	if strings.HasPrefix(dynamicRef, "#/") {
-		// For JSON pointer references, try dynamic anchor lookup first, then fall back to normal reference
-		// Get the dynamic scope chain from context
+	// Determine whether the fragment is a plain anchor name (eligible for
+	// dynamic-scope bookending) versus a JSON pointer or no fragment at all.
+	var anchorName string
+	if _, frag, found := strings.Cut(dynamicRef, "#"); found {
+		if frag != "" && !strings.HasPrefix(frag, "/") {
+			anchorName = frag
+		}
+	}
+
+	// Resolve the lexical target as $ref would.
+	var lexical schema.Schema
+	var lexErr error
+	if dynamicRef == "#"+anchorName && anchorName != "" {
+		lexErr = resolver.ResolveAnchor(refCtx, &lexical, anchorName)
+	} else {
+		lexErr = resolver.ResolveReference(refCtx, &lexical, dynamicRef)
+	}
+
+	// Bookending: only consult the dynamic scope when the lexical target declares
+	// a $dynamicAnchor matching the fragment.
+	if anchorName != "" && lexErr == nil && lexical.HasDynamicAnchor() && lexical.DynamicAnchor() == anchorName {
 		scopeChain := schema.DynamicScopeFromContext(ctx)
-
-		// Search the dynamic scope chain from oldest to most recent for matching $dynamicAnchor
-		anchorName := dynamicRef[1:] // Remove the '#' prefix
 		for i := range scopeChain {
-			currentSchema := scopeChain[i]
-
-			// Check if this schema has a matching $dynamicAnchor
-			if currentSchema.HasDynamicAnchor() && currentSchema.DynamicAnchor() == anchorName {
-				return currentSchema, nil
+			if found := schema.FindDynamicAnchor(scopeChain[i], anchorName); found != nil {
+				return found, nil
 			}
 		}
-
-		// No matching $dynamicAnchor found, fall back to normal JSON pointer resolution
-		var targetSchema schema.Schema
-		refCtx := schema.WithBaseSchema(ctx, baseSchema)
-		if err := resolver.ResolveReference(refCtx, &targetSchema, dynamicRef); err != nil {
-			return nil, fmt.Errorf("failed to resolve dynamic reference %s: %w", dynamicRef, err)
-		}
-		return &targetSchema, nil
 	}
 
-	// This is a plain anchor reference (e.g., "#anchorName")
-	anchorName := dynamicRef[1:] // Remove the '#' prefix
-
-	// Get the dynamic scope chain from context
-	scopeChain := schema.DynamicScopeFromContext(ctx)
-
-	// Search the dynamic scope chain from oldest to most recent
-	// $dynamicRef should resolve to the nearest enclosing schema with matching $dynamicAnchor
-	// "Nearest enclosing" means closest to the root, not most recently added
-	for i := range scopeChain {
-		currentSchema := scopeChain[i]
-
-		// Check if this schema has a matching $dynamicAnchor
-		if currentSchema.HasDynamicAnchor() && currentSchema.DynamicAnchor() == anchorName {
-			return currentSchema, nil
-		}
+	if lexErr != nil {
+		return nil, fmt.Errorf("failed to resolve dynamic reference %s: %w", dynamicRef, lexErr)
 	}
-
-	// If no matching $dynamicAnchor found in dynamic scope, fall back to normal anchor resolution
-	// This is the correct behavior according to JSON Schema spec
-	var targetSchema schema.Schema
-	refCtx := schema.WithBaseSchema(ctx, baseSchema)
-	if err := resolver.ResolveAnchor(refCtx, &targetSchema, anchorName); err != nil {
-		return nil, fmt.Errorf("failed to resolve dynamic reference %s (no matching $dynamicAnchor in scope): %w", dynamicRef, err)
-	}
-
-	return &targetSchema, nil
+	return &lexical, nil
 }


### PR DESCRIPTION
- resolve `$dynamicRef` against the runtime dynamic scope instead of a compile-time capture
- push schema resources onto the scope at validation time (`dynamicScopeValidator`; `$ref` entry via `Resolver.ResourceFor`)
- `DynamicReferenceValidator` resolves per-Validate with bookending (walk scope only when the lexical target declares the matching `$dynamicAnchor`)
- combine sibling keywords (e.g. `unevaluatedProperties`) on a `$dynamicRef` like `$ref` does
- dedupe `RegisterRoot` to fix a validate-time indexing data race
- spec skips 34 → 20 (all remaining are remote refs); 0 failures; race-clean
- add `validator/dynamic_scope_test.go`
