### PR TITLE
add generic Builder.Reset(flags)

### DIFF
--- a/builder_gen.go
+++ b/builder_gen.go
@@ -1244,6 +1244,171 @@ func (b *Builder) ResetVocabulary() *Builder {
 	return b
 }
 
+// Reset clears the builder fields identified by the given flags.
+// For example, b.Reset(AnchorField | PropertiesField) clears both anchor and properties.
+func (b *Builder) Reset(flags FieldFlag) *Builder {
+	if b.err != nil {
+		return b
+	}
+	if (flags & AdditionalItemsField) != 0 {
+		b.additionalItems = nil
+	}
+	if (flags & AdditionalPropertiesField) != 0 {
+		b.additionalProperties = nil
+	}
+	if (flags & AllOfField) != 0 {
+		b.allOf = nil
+	}
+	if (flags & AnchorField) != 0 {
+		b.anchor = nil
+	}
+	if (flags & AnyOfField) != 0 {
+		b.anyOf = nil
+	}
+	if (flags & CommentField) != 0 {
+		b.comment = nil
+	}
+	if (flags & ConstField) != 0 {
+		b.constantValue = nil
+	}
+	if (flags & ContainsField) != 0 {
+		b.contains = nil
+	}
+	if (flags & ContentEncodingField) != 0 {
+		b.contentEncoding = nil
+	}
+	if (flags & ContentMediaTypeField) != 0 {
+		b.contentMediaType = nil
+	}
+	if (flags & ContentSchemaField) != 0 {
+		b.contentSchema = nil
+	}
+	if (flags & DefaultField) != 0 {
+		b.defaultValue = nil
+	}
+	if (flags & DefinitionsField) != 0 {
+		b.definitions = nil
+	}
+	if (flags & DependentRequiredField) != 0 {
+		b.dependentRequired = nil
+	}
+	if (flags & DependentSchemasField) != 0 {
+		b.dependentSchemas = nil
+	}
+	if (flags & DynamicAnchorField) != 0 {
+		b.dynamicAnchor = nil
+	}
+	if (flags & DynamicReferenceField) != 0 {
+		b.dynamicReference = nil
+	}
+	if (flags & ElseSchemaField) != 0 {
+		b.elseSchema = nil
+	}
+	if (flags & EnumField) != 0 {
+		b.enum = nil
+	}
+	if (flags & ExclusiveMaximumField) != 0 {
+		b.exclusiveMaximum = nil
+	}
+	if (flags & ExclusiveMinimumField) != 0 {
+		b.exclusiveMinimum = nil
+	}
+	if (flags & FormatField) != 0 {
+		b.format = nil
+	}
+	if (flags & IDField) != 0 {
+		b.id = nil
+	}
+	if (flags & IfSchemaField) != 0 {
+		b.ifSchema = nil
+	}
+	if (flags & ItemsField) != 0 {
+		b.items = nil
+	}
+	if (flags & MaxContainsField) != 0 {
+		b.maxContains = nil
+	}
+	if (flags & MaxItemsField) != 0 {
+		b.maxItems = nil
+	}
+	if (flags & MaxLengthField) != 0 {
+		b.maxLength = nil
+	}
+	if (flags & MaxPropertiesField) != 0 {
+		b.maxProperties = nil
+	}
+	if (flags & MaximumField) != 0 {
+		b.maximum = nil
+	}
+	if (flags & MinContainsField) != 0 {
+		b.minContains = nil
+	}
+	if (flags & MinItemsField) != 0 {
+		b.minItems = nil
+	}
+	if (flags & MinLengthField) != 0 {
+		b.minLength = nil
+	}
+	if (flags & MinPropertiesField) != 0 {
+		b.minProperties = nil
+	}
+	if (flags & MinimumField) != 0 {
+		b.minimum = nil
+	}
+	if (flags & MultipleOfField) != 0 {
+		b.multipleOf = nil
+	}
+	if (flags & NotField) != 0 {
+		b.not = nil
+	}
+	if (flags & OneOfField) != 0 {
+		b.oneOf = nil
+	}
+	if (flags & PatternField) != 0 {
+		b.pattern = nil
+	}
+	if (flags & PatternPropertiesField) != 0 {
+		b.patternProperties = nil
+	}
+	if (flags & PrefixItemsField) != 0 {
+		b.prefixItems = nil
+	}
+	if (flags & PropertiesField) != 0 {
+		b.properties = nil
+	}
+	if (flags & PropertyNamesField) != 0 {
+		b.propertyNames = nil
+	}
+	if (flags & ReferenceField) != 0 {
+		b.reference = nil
+	}
+	if (flags & RequiredField) != 0 {
+		b.required = nil
+	}
+	if (flags & SchemaField) != 0 {
+		b.schema = nil
+	}
+	if (flags & ThenSchemaField) != 0 {
+		b.thenSchema = nil
+	}
+	if (flags & TypesField) != 0 {
+		b.types = nil
+	}
+	if (flags & UnevaluatedItemsField) != 0 {
+		b.unevaluatedItems = nil
+	}
+	if (flags & UnevaluatedPropertiesField) != 0 {
+		b.unevaluatedProperties = nil
+	}
+	if (flags & UniqueItemsField) != 0 {
+		b.uniqueItems = nil
+	}
+	if (flags & VocabularyField) != 0 {
+		b.vocabulary = nil
+	}
+	return b
+}
+
 func (b *Builder) Build() (*Schema, error) {
 	s := New()
 	if b.additionalItems != nil {

--- a/builder_reset_test.go
+++ b/builder_reset_test.go
@@ -1,0 +1,51 @@
+package schema_test
+
+import (
+	"testing"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilderReset(t *testing.T) {
+	build := func(t *testing.T, b *schema.Builder) *schema.Schema {
+		t.Helper()
+		s, err := b.Build()
+		require.NoError(t, err)
+		return s
+	}
+
+	newBuilder := func() *schema.Builder {
+		return schema.NewBuilder().
+			Anchor("a").
+			Comment("c").
+			Property("name", schema.NewBuilder().Types(schema.StringType).MustBuild())
+	}
+
+	t.Run("clears a single field, leaving others", func(t *testing.T) {
+		s := build(t, newBuilder().Reset(schema.AnchorField))
+		require.False(t, s.HasAnchor(), "anchor should be cleared")
+		require.True(t, s.HasComment(), "comment should remain")
+		require.True(t, s.HasProperties(), "properties should remain")
+	})
+
+	t.Run("clears multiple fields via OR-ed flags", func(t *testing.T) {
+		s := build(t, newBuilder().Reset(schema.AnchorField|schema.PropertiesField))
+		require.False(t, s.HasAnchor())
+		require.False(t, s.HasProperties())
+		require.True(t, s.HasComment(), "comment should remain")
+	})
+
+	t.Run("matches the per-field ResetXXX method", func(t *testing.T) {
+		viaGeneric := build(t, newBuilder().Reset(schema.AnchorField))
+		viaSpecific := build(t, newBuilder().ResetAnchor())
+		require.Equal(t, viaSpecific.HasAnchor(), viaGeneric.HasAnchor())
+		require.Equal(t, viaSpecific.HasProperties(), viaGeneric.HasProperties())
+	})
+
+	t.Run("is chainable and a no-op for unset flags", func(t *testing.T) {
+		s := build(t, schema.NewBuilder().Comment("c").Reset(schema.AnchorField))
+		require.True(t, s.HasComment())
+		require.False(t, s.HasAnchor())
+	})
+}

--- a/internal/cmd/genobjects/main.go
+++ b/internal/cmd/genobjects/main.go
@@ -595,6 +595,22 @@ func genBuilder(obj *codegen.Object) error {
 		o.L("}")
 	}
 
+	// Reset clears every field identified by the given flags in one call,
+	// complementing the per-field ResetXXX methods and mirroring Schema.Has.
+	o.LL("// Reset clears the builder fields identified by the given flags.")
+	o.L("// For example, b.Reset(AnchorField | PropertiesField) clears both anchor and properties.")
+	o.L("func (b *Builder) Reset(flags FieldFlag) *Builder {")
+	o.L("if b.err != nil {")
+	o.L("return b")
+	o.L("}")
+	for _, field := range obj.Fields() {
+		o.L("if (flags & %sField) != 0 {", field.Name(true))
+		o.L("b.%s = nil", field.Name(false))
+		o.L("}")
+	}
+	o.L("return b")
+	o.L("}")
+
 	o.LL("func (b *Builder) Build() (*Schema, error) {")
 	o.L("s := New()")
 	for _, field := range obj.Fields() {


### PR DESCRIPTION
- add generic `Builder.Reset(flags FieldFlag)` to clear multiple fields in one call
- complements the existing `Schema.Has(flags)`; existing `ResetXXX` methods unchanged
- generated from `internal/cmd/genobjects`; adds `builder_reset_test.go`
- salvaged from the stale PR #6 cleanup branch
