### PR TITLE
resolve remote refs via preloaded documents

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"strings"
 	"sync"
@@ -76,6 +77,60 @@ func (r *Resolver) RegisterRoot(root *Schema) {
 	}
 	r.index.index(root, base, make(map[*Schema]struct{}))
 	r.mu.Unlock()
+}
+
+// RegisterDocument registers a document retrieved from (or identified by) an
+// explicit URI, so references to that URI resolve from memory instead of being
+// fetched. The document is addressable both by uri and by its own canonical $id
+// (resolved against uri), and its nested $id resources and anchors are indexed.
+// This is how callers preload remote/bundled schemas without network access.
+func (r *Resolver) RegisterDocument(uri string, root *Schema) {
+	if r.index == nil || root == nil || uri == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.registered == nil {
+		r.registered = make(map[*Schema]struct{})
+	}
+	r.registered[root] = struct{}{}
+
+	retrieval, _, _ := splitFragment(uri)
+	base := retrieval
+	if root.HasID() && root.ID() != "" {
+		base, _, _ = splitFragment(resolveURI(retrieval, root.ID()))
+	}
+	// Address the document by its retrieval URI even when it has no $id of its own.
+	r.index.byURI[retrieval] = root
+	r.index.index(root, base, make(map[*Schema]struct{}))
+}
+
+// RegisterFS walks fsys and registers every ".json" file as a document via
+// RegisterDocument, addressed at baseURI joined with the file's (slash-separated)
+// path. It lets a whole tree of schemas — an embed.FS, os.DirFS, zip, etc. — be
+// preloaded for offline resolution in one call. Files that do not parse as an
+// object schema (e.g. a boolean schema document) are skipped; read/walk errors
+// are returned.
+func (r *Resolver) RegisterFS(baseURI string, fsys fs.FS) error {
+	prefix := strings.TrimSuffix(baseURI, "/")
+	return fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".json") {
+			return nil
+		}
+		data, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return err
+		}
+		var s Schema
+		if s.UnmarshalJSON(data) != nil {
+			return nil //nolint:nilerr // not an object schema (e.g. boolean document): skip it
+		}
+		r.RegisterDocument(prefix+"/"+path, &s)
+		return nil
+	})
 }
 
 // ResourceFor returns the schema resource registered under the given absolute

--- a/schema_compliance_test.go
+++ b/schema_compliance_test.go
@@ -13,6 +13,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newSuiteResolver returns a resolver preloaded with the JSON Schema Test Suite
+// remote documents (tests/remotes, served at http://localhost:1234/...), so that
+// remote references resolve from memory instead of the network.
+func newSuiteResolver(t *testing.T) *schema.Resolver {
+	t.Helper()
+	r := schema.NewResolver()
+	require.NoError(t, r.RegisterFS("http://localhost:1234", os.DirFS(filepath.Join("tests", "remotes"))))
+	return r
+}
+
 // Test JSON Schema 2020-12 Core Specification Compliance
 func TestJSONSchema2020_12_CoreCompliance(t *testing.T) {
 	t.Parallel()
@@ -474,8 +484,10 @@ func runTestSuite(t *testing.T, testSuite TestSuite) {
 		}
 	}
 
-	// Compile the schema to a validator
-	v, err := validator.Compile(context.Background(), s)
+	// Compile the schema to a validator, with the suite's remote documents
+	// preloaded so http://localhost:1234/... references resolve offline.
+	ctx := schema.WithResolver(context.Background(), newSuiteResolver(t))
+	v, err := validator.Compile(ctx, s)
 	if err != nil {
 		t.Skipf("Failed to compile schema: %v", err)
 		return

--- a/validator/compiler.go
+++ b/validator/compiler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	schema "github.com/lestrrat-go/json-schema"
 	"github.com/lestrrat-go/json-schema/internal/schemactx"
@@ -59,8 +60,28 @@ func combineReferenceWithConstraints(ctx context.Context, s *schema.Schema, reso
 	return AllOf(resolvedValidator, additionalValidator), nil
 }
 
+// skipIDRebaseKey marks that the caller already set the base URI to the target
+// resource's canonical URI (from the registry), so compileSchema must not
+// re-base the target's $id again (which would double a path segment).
+type skipIDRebaseKey struct{}
+
+func withSkipIDRebase(ctx context.Context) context.Context {
+	return context.WithValue(ctx, skipIDRebaseKey{}, true)
+}
+
+// consumeSkipIDRebase reports whether the skip flag is set and returns a context
+// with it cleared, so the suppression applies only to the immediate schema and
+// not to its nested subschemas.
+func consumeSkipIDRebase(ctx context.Context) (context.Context, bool) {
+	if v, _ := ctx.Value(skipIDRebaseKey{}).(bool); v {
+		return context.WithValue(ctx, skipIDRebaseKey{}, false), true
+	}
+	return ctx, false
+}
+
 // compileSchema implements the simplified compilation approach using UnevaluatedCoordinator.
 func compileSchema(ctx context.Context, s *schema.Schema) (Interface, error) {
+	ctx, skipIDRebase := consumeSkipIDRebase(ctx)
 	// Set up context with default resolver if none provided
 	if schema.ResolverFromContext(ctx) == nil {
 		ctx = schema.WithResolver(ctx, schema.NewResolver())
@@ -105,7 +126,7 @@ func compileSchema(ctx context.Context, s *schema.Schema) (Interface, error) {
 	// the base URI and the base schema so that this resource's relative refs
 	// (e.g. "./bar.json") and local pointers (e.g. "#/$defs/inner") resolve
 	// against this resource rather than an enclosing one.
-	if s.HasID() && s.ID() != "" {
+	if s.HasID() && s.ID() != "" && !skipIDRebase {
 		parentBase := schema.BaseURIFromContext(ctx)
 		if absBase := schema.ResolveURI(parentBase, s.ID()); absBase != "" {
 			ctx = schema.WithBaseURI(ctx, absBase)
@@ -277,14 +298,35 @@ func compileSchema(ctx context.Context, s *schema.Schema) (Interface, error) {
 			return AllOf(resolvedValidator, additionalValidator), nil
 		}
 
-		// Schema has only $ref, recursively compile the resolved schema
-		// Set up context for the resolved schema with proper base schema context
-
-		// Only set resolved schema as base if it has its own ID (proper schema scope)
-		// Otherwise keep existing base schema that was able to resolve the reference
+		// Schema has only $ref: recursively compile the resolved schema.
 		resolvedCtx := ctx
-		if targetSchema.HasID() {
-			resolvedCtx = schema.WithBaseSchema(ctx, &targetSchema)
+		var resource *schema.Schema
+		if strings.HasPrefix(reference, "#") {
+			// Local reference: the target lives in the current resource, so the
+			// base URI must not change. Re-base only if the target carries its own
+			// $id.
+			if targetSchema.HasID() {
+				resolvedCtx = schema.WithBaseSchema(ctx, &targetSchema)
+			}
+		} else {
+			// A reference into another document/resource. Its base URI is the
+			// reference's absolute (retrieval) URI, so the target's own relative
+			// references (e.g. "string.json") resolve against where it lives, and
+			// its local "#/..." pointers resolve within the enclosing resource.
+			absBase, _, _ := strings.Cut(schema.ResolveURI(baseURI, reference), "#")
+			resource = resolver.ResourceFor(absBase)
+			if absBase != "" {
+				resolvedCtx = schema.WithBaseURI(resolvedCtx, absBase)
+			}
+			switch {
+			case resource != nil:
+				// absBase is the resource's canonical registry URI, so suppress the
+				// $id re-base in compileSchema (it would double a path segment).
+				resolvedCtx = schema.WithBaseSchema(resolvedCtx, resource)
+				resolvedCtx = withSkipIDRebase(resolvedCtx)
+			case targetSchema.HasID():
+				resolvedCtx = schema.WithBaseSchema(resolvedCtx, &targetSchema)
+			}
 		}
 		compiled, err := Compile(resolvedCtx, &targetSchema)
 		if err != nil {
@@ -292,7 +334,7 @@ func compileSchema(ctx context.Context, s *schema.Schema) (Interface, error) {
 		}
 		// Following the $ref enters the target's resource; record it on the
 		// dynamic scope so a $dynamicRef deeper in the target can find it.
-		if resource := resolver.ResourceFor(schema.ResolveURI(baseURI, reference)); resource != nil && resource != &targetSchema {
+		if resource != nil && resource != &targetSchema {
 			compiled = &dynamicScopeValidator{schema: resource, inner: compiled}
 		}
 		return compiled, nil

--- a/validator/remote_fs_test.go
+++ b/validator/remote_fs_test.go
@@ -1,0 +1,45 @@
+package validator_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisterFS verifies that a tree of schemas exposed as an fs.FS (here an
+// in-memory fstest.MapFS, but equally an embed.FS or os.DirFS) can be preloaded
+// in one call and referenced by URL, with relative refs resolving within the FS.
+func TestRegisterFS(t *testing.T) {
+	fsys := fstest.MapFS{
+		"integer.json":       {Data: []byte(`{"type":"integer"}`)},
+		"nested/foo.json":    {Data: []byte(`{"type":"object","properties":{"name":{"$ref":"string.json"}}}`)},
+		"nested/string.json": {Data: []byte(`{"type":"string"}`)},
+		"notschema.txt":      {Data: []byte(`ignored`)},
+	}
+
+	r := schema.NewResolver()
+	require.NoError(t, r.RegisterFS("http://localhost:1234", fsys))
+
+	var top schema.Schema
+	require.NoError(t, top.UnmarshalJSON([]byte(`{"$ref":"http://localhost:1234/integer.json"}`)))
+	ctx := schema.WithResolver(t.Context(), r)
+	v, err := validator.Compile(ctx, &top)
+	require.NoError(t, err)
+	_, err = v.Validate(t.Context(), 7)
+	require.NoError(t, err)
+	_, err = v.Validate(t.Context(), "nope")
+	require.Error(t, err)
+
+	// Relative ref inside a registered FS document resolves within the FS.
+	var nested schema.Schema
+	require.NoError(t, nested.UnmarshalJSON([]byte(`{"$ref":"http://localhost:1234/nested/foo.json"}`)))
+	v, err = validator.Compile(ctx, &nested)
+	require.NoError(t, err)
+	_, err = v.Validate(t.Context(), map[string]any{"name": "ok"})
+	require.NoError(t, err)
+	_, err = v.Validate(t.Context(), map[string]any{"name": 1})
+	require.Error(t, err)
+}

--- a/validator/remote_ref_test.go
+++ b/validator/remote_ref_test.go
@@ -1,0 +1,55 @@
+package validator_test
+
+import (
+	"testing"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteRefViaRegisterDocument verifies that documents preloaded with
+// Resolver.RegisterDocument resolve from memory (no network), including relative
+// references inside a preloaded document resolving against its retrieval URI.
+func TestRemoteRefViaRegisterDocument(t *testing.T) {
+	mustParse := func(t *testing.T, src string) *schema.Schema {
+		t.Helper()
+		var s schema.Schema
+		require.NoError(t, s.UnmarshalJSON([]byte(src)))
+		return &s
+	}
+
+	t.Run("ref to a registered remote document", func(t *testing.T) {
+		r := schema.NewResolver()
+		r.RegisterDocument("http://localhost:1234/integer.json", mustParse(t, `{"type":"integer"}`))
+
+		s := mustParse(t, `{"$ref":"http://localhost:1234/integer.json"}`)
+		ctx := schema.WithResolver(t.Context(), r)
+		v, err := validator.Compile(ctx, s)
+		require.NoError(t, err)
+
+		_, err = v.Validate(t.Context(), 42)
+		require.NoError(t, err)
+		_, err = v.Validate(t.Context(), "not an integer")
+		require.Error(t, err)
+	})
+
+	t.Run("relative ref inside a remote resolves against its retrieval URI", func(t *testing.T) {
+		r := schema.NewResolver()
+		// foo.json lives in nested/ and references its sibling string.json.
+		r.RegisterDocument("http://localhost:1234/nested/foo.json",
+			mustParse(t, `{"type":"object","properties":{"name":{"$ref":"string.json"}}}`))
+		r.RegisterDocument("http://localhost:1234/nested/string.json",
+			mustParse(t, `{"type":"string"}`))
+
+		s := mustParse(t, `{"$ref":"http://localhost:1234/nested/foo.json"}`)
+		ctx := schema.WithResolver(t.Context(), r)
+		v, err := validator.Compile(ctx, s)
+		require.NoError(t, err)
+
+		_, err = v.Validate(t.Context(), map[string]any{"name": "ok"})
+		require.NoError(t, err)
+		_, err = v.Validate(t.Context(), map[string]any{"name": 123})
+		require.Error(t, err, "name must be a string per the sibling-resolved string.json")
+	})
+}


### PR DESCRIPTION
- add `Resolver.RegisterDocument(uri, root)` to preload a document under an explicit URI (offline/bundled remotes)
- add `Resolver.RegisterFS(baseURI, fs.FS)` to preload a whole tree (embed.FS / os.DirFS / fstest) in one call
- on a `$ref` into another resource, set the base URI to its retrieval URI and base schema to the enclosing resource; suppress a double `$id` re-base when the target is an already-registered resource
- spec test now preloads the suite's `remotes/` via `RegisterFS`
- entire required 2020-12 suite passes: 1723 pass, 0 fail, 0 skip (was 20 skip)
- add `validator/remote_ref_test.go`, `validator/remote_fs_test.go`
