### PR TITLE
drop reflection from schemactx accessors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,20 +3,20 @@ module github.com/lestrrat-go/json-schema
 go 1.24.4
 
 require (
-	github.com/lestrrat-go/blackmagic v1.0.4
 	github.com/lestrrat-go/codegen v1.0.4
 	github.com/lestrrat-go/jsref/v2 v2.0.0-20250713032959-1507af0872ba
 	github.com/stretchr/testify v1.10.0
+	github.com/urfave/cli/v3 v3.3.8
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect
+	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
 	github.com/lestrrat-go/jsptr v0.0.0-20250712081548-ece4951ef7eb // indirect
 	github.com/lestrrat-go/option v1.0.0 // indirect
 	github.com/lestrrat-go/xstrings v0.0.0-20210804220435-4dd8b234342b // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/urfave/cli/v3 v3.3.8 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
 	golang.org/x/mod v0.3.0 // indirect
 	golang.org/x/tools v0.0.0-20200918232735-d647fc253266 // indirect

--- a/internal/schemactx/context.go
+++ b/internal/schemactx/context.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-
-	"github.com/lestrrat-go/blackmagic"
 )
 
 type EvaluatedProperties struct {
@@ -124,6 +122,42 @@ func ValidationContextFrom(ctx context.Context) *ValidationContext {
 	return &ValidationContext{}
 }
 
+// valueFromContext is the shared core of every typed accessor below. It takes
+// the raw field value, a flag reporting whether that field is actually present
+// (each field carries its own emptiness rule — nil pointer, "" string, empty
+// slice), and a human-readable name for error messages. It returns the value
+// asserted to the caller-requested type T.
+//
+// PROGRESSION NOTE: when Go gains parameterized methods this helper, together
+// with the per-field accessors, collapses into methods on *ValidationContext,
+// e.g.
+//
+//	func (v *ValidationContext) Resolver[T any]() (T, error)
+//	func (v *ValidationContext) BaseURI() (string, error)
+//
+// At that point a call like
+//
+//	schemactx.ResolverFromContext[*Resolver](ctx)
+//
+// becomes
+//
+//	schemactx.ValidationContextFrom(ctx).Resolver[*Resolver]()
+//
+// which is a mechanical, type-preserving change. The public schema.go wrappers
+// (ResolverFromContext(ctx) *Resolver, ...) do not change in either step, so
+// callers outside this package are insulated from the migration.
+func valueFromContext[T any](raw any, present bool, what string) (T, error) {
+	var zero T
+	if !present {
+		return zero, fmt.Errorf("%s not found in context", what)
+	}
+	v, ok := raw.(T)
+	if !ok {
+		return zero, fmt.Errorf("%s in context has incompatible type %T", what, raw)
+	}
+	return v, nil
+}
+
 // Consolidated context functions using ValidationContext
 
 // WithResolver adds a resolver to the consolidated validation context
@@ -134,13 +168,11 @@ func WithResolver(ctx context.Context, resolver any) context.Context {
 	return WithValidationContext(ctx, &newVctx)
 }
 
-// ResolverFromContext retrieves the resolver from context, returns error if not present or incompatible
-func ResolverFromContext(ctx context.Context, dst any) error {
+// ResolverFromContext retrieves the resolver from context, returns error if not present or incompatible.
+// Generic because the concrete resolver type lives in the parent package and cannot be named here.
+func ResolverFromContext[T any](ctx context.Context) (T, error) {
 	vctx := ValidationContextFrom(ctx)
-	if vctx.Resolver == nil {
-		return fmt.Errorf("resolver not found in context")
-	}
-	return blackmagic.AssignIfCompatible(dst, vctx.Resolver)
+	return valueFromContext[T](vctx.Resolver, vctx.Resolver != nil, "resolver")
 }
 
 // WithRootSchema adds a root schema to the context
@@ -151,13 +183,11 @@ func WithRootSchema(ctx context.Context, rootSchema any) context.Context {
 	return WithValidationContext(ctx, &newVctx)
 }
 
-// RootSchemaFromContext retrieves the root schema from context, returns error if not present or incompatible
-func RootSchemaFromContext(ctx context.Context, dst any) error {
+// RootSchemaFromContext retrieves the root schema from context, returns error if not present or incompatible.
+// Generic because the concrete schema type lives in the parent package and cannot be named here.
+func RootSchemaFromContext[T any](ctx context.Context) (T, error) {
 	vctx := ValidationContextFrom(ctx)
-	if vctx.RootSchema == nil {
-		return fmt.Errorf("root schema not found in context")
-	}
-	return blackmagic.AssignIfCompatible(dst, vctx.RootSchema)
+	return valueFromContext[T](vctx.RootSchema, vctx.RootSchema != nil, "root schema")
 }
 
 // WithBaseSchema adds a base schema to the context for reference resolution
@@ -168,13 +198,11 @@ func WithBaseSchema(ctx context.Context, baseSchema any) context.Context {
 	return WithValidationContext(ctx, &newVctx)
 }
 
-// BaseSchemaFromContext retrieves the base schema from context, returns error if not present or incompatible
-func BaseSchemaFromContext(ctx context.Context, dst any) error {
+// BaseSchemaFromContext retrieves the base schema from context, returns error if not present or incompatible.
+// Generic because the concrete schema type lives in the parent package and cannot be named here.
+func BaseSchemaFromContext[T any](ctx context.Context) (T, error) {
 	vctx := ValidationContextFrom(ctx)
-	if vctx.BaseSchema == nil {
-		return fmt.Errorf("base schema not found in context")
-	}
-	return blackmagic.AssignIfCompatible(dst, vctx.BaseSchema)
+	return valueFromContext[T](vctx.BaseSchema, vctx.BaseSchema != nil, "base schema")
 }
 
 // WithBaseURI adds a base URI to the context for reference resolution
@@ -185,13 +213,11 @@ func WithBaseURI(ctx context.Context, baseURI string) context.Context {
 	return WithValidationContext(ctx, &newVctx)
 }
 
-// BaseURIFromContext extracts the base URI from context, returns error if not present or incompatible
-func BaseURIFromContext(ctx context.Context, dst any) error {
+// BaseURIFromContext extracts the base URI from context, returns error if not present.
+// Concrete return type: string is nameable here, so no type parameter is needed.
+func BaseURIFromContext(ctx context.Context) (string, error) {
 	vctx := ValidationContextFrom(ctx)
-	if vctx.BaseURI == "" {
-		return fmt.Errorf("base URI not found in context")
-	}
-	return blackmagic.AssignIfCompatible(dst, vctx.BaseURI)
+	return valueFromContext[string](vctx.BaseURI, vctx.BaseURI != "", "base URI")
 }
 
 // WithDynamicScope adds a schema to the dynamic scope chain in the context
@@ -208,13 +234,12 @@ func WithDynamicScope(ctx context.Context, s any) context.Context {
 	return WithValidationContext(ctx, &newVctx)
 }
 
-// DynamicScopeFromContext retrieves the dynamic scope chain from context, returns error if not present or incompatible
-func DynamicScopeFromContext(ctx context.Context, dst any) error {
+// DynamicScopeFromContext retrieves the dynamic scope chain from context, returns error if not present.
+// The chain is stored as []any (its elements are schemas from the parent package); callers convert
+// the elements to their concrete type.
+func DynamicScopeFromContext(ctx context.Context) ([]any, error) {
 	vctx := ValidationContextFrom(ctx)
-	if len(vctx.DynamicScope) == 0 {
-		return fmt.Errorf("dynamic scope not found in context")
-	}
-	return blackmagic.AssignIfCompatible(dst, vctx.DynamicScope)
+	return valueFromContext[[]any](vctx.DynamicScope, len(vctx.DynamicScope) > 0, "dynamic scope")
 }
 
 // WithVocabularySet adds a vocabulary set to the context
@@ -225,13 +250,11 @@ func WithVocabularySet(ctx context.Context, vocabSet any) context.Context {
 	return WithValidationContext(ctx, &newVctx)
 }
 
-// VocabularySetFromContext retrieves the vocabulary set from context, returns error if not present or incompatible
-func VocabularySetFromContext(ctx context.Context, dst any) error {
+// VocabularySetFromContext retrieves the vocabulary set from context, returns error if not present or incompatible.
+// Generic because the concrete vocabulary type lives in the vocabulary package and cannot be named here.
+func VocabularySetFromContext[T any](ctx context.Context) (T, error) {
 	vctx := ValidationContextFrom(ctx)
-	if vctx.VocabularySet == nil {
-		return fmt.Errorf("vocabulary set not found in context")
-	}
-	return blackmagic.AssignIfCompatible(dst, vctx.VocabularySet)
+	return valueFromContext[T](vctx.VocabularySet, vctx.VocabularySet != nil, "vocabulary set")
 }
 
 // WithReferenceStack adds a reference stack to the context for circular reference detection
@@ -242,13 +265,11 @@ func WithReferenceStack(ctx context.Context, stack []string) context.Context {
 	return WithValidationContext(ctx, &newVctx)
 }
 
-// ReferenceStackFromContext retrieves the reference stack from context, returns error if not present or incompatible
-func ReferenceStackFromContext(ctx context.Context, dst any) error {
+// ReferenceStackFromContext retrieves the reference stack from context, returns error if not present.
+// Concrete return type: []string is nameable here, so no type parameter is needed.
+func ReferenceStackFromContext(ctx context.Context) ([]string, error) {
 	vctx := ValidationContextFrom(ctx)
-	if len(vctx.ReferenceStack) == 0 {
-		return fmt.Errorf("reference stack not found in context")
-	}
-	return blackmagic.AssignIfCompatible(dst, vctx.ReferenceStack)
+	return valueFromContext[[]string](vctx.ReferenceStack, len(vctx.ReferenceStack) > 0, "reference stack")
 }
 
 // WithRefDepths stores the per-reference data-depth map used to distinguish
@@ -286,12 +307,11 @@ func WithEvaluationContext(ctx context.Context, ec *EvaluationContext) context.C
 	return WithValidationContext(ctx, &newVctx)
 }
 
-func EvaluationContextFromContext(ctx context.Context, dst any) error {
+// EvaluationContextFromContext retrieves the evaluation context, returns error if not present.
+// Concrete return type: *EvaluationContext is defined in this package, so no type parameter is needed.
+func EvaluationContextFromContext(ctx context.Context) (*EvaluationContext, error) {
 	vctx := ValidationContextFrom(ctx)
-	if vctx.Evaluation == nil {
-		return fmt.Errorf("evaluated items not found in context")
-	}
-	return blackmagic.AssignIfCompatible(dst, vctx.Evaluation)
+	return valueFromContext[*EvaluationContext](vctx.Evaluation, vctx.Evaluation != nil, "evaluation context")
 }
 
 // Logging context functions

--- a/resolver.go
+++ b/resolver.go
@@ -150,10 +150,7 @@ func (r *Resolver) ResourceFor(uri string) *Schema {
 // This method supports local JSON pointer references such as "#/$defs/person", relative references such as "person.json#/$defs/person", and absolute references such as "https://example.com/schemas/person.json#/$defs/person".
 // This method only handles JSON pointer references, not anchor references.
 func (r *Resolver) ResolveJSONReference(ctx context.Context, dst *Schema, reference string) error {
-	var baseSchema *Schema
-	if err := schemactx.BaseSchemaFromContext(ctx, &baseSchema); err != nil {
-		baseSchema = nil
-	}
+	baseSchema, _ := schemactx.BaseSchemaFromContext[*Schema](ctx)
 	// If the reference is a pure local reference into the current document:
 	// either a JSON pointer ("#/...") or a bare "#" denoting the document root.
 	if reference == "#" || (len(reference) > 1 && reference[0] == '#' && reference[1] == '/') {
@@ -207,8 +204,8 @@ func (r *Resolver) ResolveJSONReference(ctx context.Context, dst *Schema, refere
 // It searches for schemas with the specified $anchor value within the base schema.
 // The anchorName parameter should not include the # prefix.
 func (r *Resolver) ResolveAnchor(ctx context.Context, dst *Schema, anchorName string) error {
-	var baseSchema *Schema
-	if err := schemactx.BaseSchemaFromContext(ctx, &baseSchema); err != nil {
+	baseSchema, err := schemactx.BaseSchemaFromContext[*Schema](ctx)
+	if err != nil {
 		return fmt.Errorf("no base schema provided in context for resolving anchor %s: %w", anchorName, err)
 	}
 
@@ -240,10 +237,7 @@ func (r *Resolver) ResolveReference(ctx context.Context, dst *Schema, reference 
 		// can then recognize it as a known $id resource before any external
 		// retrieval is attempted; if it is genuinely external the absolute form
 		// is what HTTP/filesystem resolution needs anyway.
-		var baseURI string
-		if err := schemactx.BaseURIFromContext(ctx, &baseURI); err != nil {
-			baseURI = ""
-		}
+		baseURI, _ := schemactx.BaseURIFromContext(ctx)
 		if baseURI != "" {
 			resolvedReference = resolveURI(baseURI, reference)
 		}

--- a/schema.go
+++ b/schema.go
@@ -227,8 +227,8 @@ func WithBaseSchema(ctx context.Context, baseSchema *Schema) context.Context {
 
 // BaseSchemaFromContext retrieves the base schema from context, returns nil if not found
 func BaseSchemaFromContext(ctx context.Context) *Schema {
-	var baseSchema *Schema
-	if err := schemactx.BaseSchemaFromContext(ctx, &baseSchema); err != nil {
+	baseSchema, err := schemactx.BaseSchemaFromContext[*Schema](ctx)
+	if err != nil {
 		return nil
 	}
 	return baseSchema
@@ -241,8 +241,8 @@ func WithResolver(ctx context.Context, resolver *Resolver) context.Context {
 
 // ResolverFromContext retrieves the resolver from context, returns nil if not found
 func ResolverFromContext(ctx context.Context) *Resolver {
-	var resolver *Resolver
-	if err := schemactx.ResolverFromContext(ctx, &resolver); err != nil {
+	resolver, err := schemactx.ResolverFromContext[*Resolver](ctx)
+	if err != nil {
 		return nil
 	}
 	return resolver
@@ -255,8 +255,8 @@ func WithRootSchema(ctx context.Context, rootSchema *Schema) context.Context {
 
 // RootSchemaFromContext retrieves the root schema from context, returns nil if not found
 func RootSchemaFromContext(ctx context.Context) *Schema {
-	var rootSchema *Schema
-	if err := schemactx.RootSchemaFromContext(ctx, &rootSchema); err != nil {
+	rootSchema, err := schemactx.RootSchemaFromContext[*Schema](ctx)
+	if err != nil {
 		return nil
 	}
 	return rootSchema
@@ -269,8 +269,8 @@ func WithBaseURI(ctx context.Context, baseURI string) context.Context {
 
 // BaseURIFromContext extracts the base URI from context, returns empty string if not present
 func BaseURIFromContext(ctx context.Context) string {
-	var baseURI string
-	if err := schemactx.BaseURIFromContext(ctx, &baseURI); err != nil {
+	baseURI, err := schemactx.BaseURIFromContext(ctx)
+	if err != nil {
 		return ""
 	}
 	return baseURI
@@ -283,8 +283,8 @@ func WithDynamicScope(ctx context.Context, s *Schema) context.Context {
 
 // DynamicScopeFromContext retrieves the dynamic scope chain from context, returns nil if not present
 func DynamicScopeFromContext(ctx context.Context) []*Schema {
-	var scope []any
-	if err := schemactx.DynamicScopeFromContext(ctx, &scope); err != nil {
+	scope, err := schemactx.DynamicScopeFromContext(ctx)
+	if err != nil {
 		return nil
 	}
 
@@ -305,8 +305,8 @@ func WithReferenceStack(ctx context.Context, stack []string) context.Context {
 
 // ReferenceStackFromContext retrieves the reference stack from context, returns nil if not present
 func ReferenceStackFromContext(ctx context.Context) []string {
-	var stack []string
-	if err := schemactx.ReferenceStackFromContext(ctx, &stack); err != nil {
+	stack, err := schemactx.ReferenceStackFromContext(ctx)
+	if err != nil {
 		return nil
 	}
 	return stack

--- a/validator/array.go
+++ b/validator/array.go
@@ -295,7 +295,9 @@ func (c *arrayValidator) Validate(ctx context.Context, v any) (Result, error) {
 	acc, isArray := newArrayAccessor(v)
 
 	var ec schemactx.EvaluationContext
-	_ = schemactx.EvaluationContextFromContext(ctx, &ec)
+	if ecPtr, _ := schemactx.EvaluationContextFromContext(ctx); ecPtr != nil {
+		ec = *ecPtr
+	}
 
 	if !isArray {
 		// Handle non-array values based on whether this is strict array type validation

--- a/validator/compiler.go
+++ b/validator/compiler.go
@@ -112,8 +112,7 @@ func compileSchema(ctx context.Context, s *schema.Schema) (Interface, error) {
 
 	// Set up vocabulary context if none provided
 	// Default to JSON Schema 2020-12 default vocabulary (format-assertion disabled)
-	var vocabSet *vocabulary.VocabularySet
-	if err := schemactx.VocabularySetFromContext(ctx, &vocabSet); err != nil {
+	if _, err := schemactx.VocabularySetFromContext[*vocabulary.VocabularySet](ctx); err != nil {
 		// No vocabulary set in context, use default vocabulary per JSON Schema spec
 		ctx = vocabulary.WithSet(ctx, vocabulary.DefaultSet())
 	}

--- a/validator/object.go
+++ b/validator/object.go
@@ -350,8 +350,7 @@ func extractObjectProperties(v any) (map[string]any, bool, error) {
 // Validate implements the Interface
 func (c *objectValidator) Validate(ctx context.Context, v any) (Result, error) {
 	// Get previously evaluated properties from context
-	var ec *schemactx.EvaluationContext
-	_ = schemactx.EvaluationContextFromContext(ctx, &ec)
+	ec, _ := schemactx.EvaluationContextFromContext(ctx)
 	if ec == nil {
 		ec = &schemactx.EvaluationContext{}
 	}

--- a/validator/unevaluated_coordinator.go
+++ b/validator/unevaluated_coordinator.go
@@ -99,7 +99,9 @@ func (v *unevaluatedCoordinator) validateUnevaluatedProperties(ctx context.Conte
 
 	// Also check context for previously evaluated properties
 	var ec schemactx.EvaluationContext
-	_ = schemactx.EvaluationContextFromContext(ctx, &ec)
+	if ecPtr, _ := schemactx.EvaluationContextFromContext(ctx); ecPtr != nil {
+		ec = *ecPtr
+	}
 	contextPropKeys := ec.Properties.Keys()
 
 	// Merge context and current evaluations
@@ -177,7 +179,9 @@ func (v *unevaluatedCoordinator) validateUnevaluatedItems(ctx context.Context, i
 
 	// Also check context for previously evaluated items
 	var ec schemactx.EvaluationContext
-	_ = schemactx.EvaluationContextFromContext(ctx, &ec)
+	if ecPtr, _ := schemactx.EvaluationContextFromContext(ctx); ecPtr != nil {
+		ec = *ecPtr
+	}
 	contextItems := ec.Items.Values()
 
 	// Merge context and current evaluations

--- a/vocabulary/vocabulary.go
+++ b/vocabulary/vocabulary.go
@@ -316,8 +316,8 @@ func WithSet(ctx context.Context, vocabSet *VocabularySet) context.Context {
 
 // SetFromContext extracts the vocabulary set from the context
 func SetFromContext(ctx context.Context) *VocabularySet {
-	var vocabSet *VocabularySet
-	if err := schemactx.VocabularySetFromContext(ctx, &vocabSet); err != nil {
+	vocabSet, err := schemactx.VocabularySetFromContext[*VocabularySet](ctx)
+	if err != nil {
 		return DefaultSet() // Use default vocabulary set with format-assertion disabled
 	}
 	return vocabSet


### PR DESCRIPTION
- Replace reflection-based `blackmagic.AssignIfCompatible` in `schemactx` context accessors with a generic type-asserting helper; `blackmagic` is now indirect-only (via `jsref`)
- Accessors return `(T, error)`: generic where the concrete type lives in a parent package (`Resolver`/`RootSchema`/`BaseSchema`/`VocabularySet`), concrete otherwise
- Helper is the seam for a future `Get[T]()` parameterized method; public `schema.go` wrappers and `EvaluationContext` copy/share semantics are unchanged
