### PR TITLE
fix $dynamicRef nil-base panic in meta validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,26 @@ on:
       - develop/*
 
 jobs:
+  generate:
+    runs-on: ubuntu-latest
+    name: "Check generated files are up to date"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install Go stable version
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: "go.mod"
+          check-latest: true
+      - name: Regenerate code
+        run: go generate ./...
+      - name: Verify no changes
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::Generated files are out of date. Run 'go generate ./...' and commit the result."
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/gen.sh
+++ b/gen.sh
@@ -17,3 +17,15 @@ $dir/internal/cmd/genobjects/genobjects -objects=$dir/internal/cmd/genobjects/ob
 popd
 
 rm $dir/internal/cmd/genobjects/genobjects
+
+# Regenerate the precompiled 2020-12 meta-schema validator (meta/meta_gen.go).
+# genmeta embeds its meta-schema inputs, so this needs no network access.
+pushd $dir/internal/cmd/genmeta
+go build -o genmeta main.go
+popd
+
+pushd $dir
+$dir/internal/cmd/genmeta/genmeta
+popd
+
+rm $dir/internal/cmd/genmeta/genmeta

--- a/internal/cmd/genmeta/main.go
+++ b/internal/cmd/genmeta/main.go
@@ -4,17 +4,36 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/json"
+	"embed"
 	"fmt"
 	"go/format"
+	"io/fs"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	schema "github.com/lestrrat-go/json-schema"
 	"github.com/lestrrat-go/json-schema/validator"
 	"github.com/lestrrat-go/json-schema/vocabulary"
+)
+
+// schemaFS holds the JSON Schema 2020-12 meta-schema and its vocabulary
+// documents, copied verbatim from the published spec (with the canonical
+// json-schema.org URIs). They are embedded so generation is hermetic: it needs
+// no network access and is reproducible from version-controlled inputs.
+//
+//go:embed schemas
+var schemaFS embed.FS
+
+const (
+	// schemaRoot is the directory inside schemaFS that holds the 2020-12 documents.
+	schemaRoot = "schemas/2020-12"
+	// baseURI is the canonical retrieval base the embedded documents are addressed
+	// under. The root meta-schema's $id is baseURI+"schema"; its vocabulary
+	// documents are baseURI+"meta/<name>".
+	baseURI = "https://json-schema.org/draft/2020-12/"
+	// rootRef is the canonical URI of the root meta-schema document.
+	rootRef = baseURI + "schema"
 )
 
 func main() {
@@ -25,129 +44,45 @@ func main() {
 }
 
 func _main() error {
-	// Get the root directory (where main go.mod is located)
 	rootDir, err := findRootDir()
 	if err != nil {
 		return fmt.Errorf("failed to find root directory: %w", err)
 	}
 
-	// Load the main meta-schema
-	metaSchemaPath := filepath.Join(rootDir, "metaschema-2020-12.json")
-	metaSchemaData, err := os.ReadFile(metaSchemaPath)
-	if err != nil {
-		return fmt.Errorf("failed to read meta-schema file %q: %w", metaSchemaPath, err)
-	}
-
-	// Parse the meta-schema
-	var metaSchema schema.Schema
-	if err := json.Unmarshal(metaSchemaData, &metaSchema); err != nil {
-		return fmt.Errorf("failed to unmarshal meta-schema: %w", err)
-	}
-
-	fmt.Printf("Successfully loaded meta-schema with ID: %s\n", metaSchema.ID())
-
-	// Debug: Raw JSON check
-	if bytes.Contains(metaSchemaData, []byte(`"type"`)) {
-		fmt.Printf("Raw JSON contains 'type' field\n")
-	} else {
-		fmt.Printf("Raw JSON does NOT contain 'type' field\n")
-	}
-
-	// Debug: Check if meta-schema has types
-	if metaSchema.HasTypes() {
-		types := metaSchema.Types()
-		fmt.Printf("Meta-schema has types: %v\n", types)
-
-		// Debug: Test type compilation in isolation
-		fmt.Printf("Testing if 'type' keyword is enabled in context...\n")
-		testCtx := context.Background()
-		testVocabSet := vocabulary.AllEnabled()
-		testCtx = vocabulary.WithSet(testCtx, testVocabSet)
-		isTypeEnabled := vocabulary.IsKeywordEnabledInContext(testCtx, "type")
-		fmt.Printf("Type keyword enabled: %v\n", isTypeEnabled)
-
-		// Debug: Test what base schema would be created
-		fmt.Printf("Simulating createBaseSchema behavior...\n")
-		baseBuilder := schema.NewBuilder()
-		if len(metaSchema.Types()) > 0 {
-			baseBuilder.Types(metaSchema.Types()...)
-			fmt.Printf("Base schema would have types: %v\n", metaSchema.Types())
-		}
-		baseSchema := baseBuilder.MustBuild()
-
-		// Test compiling the base schema in isolation
-		baseValidator, err := validator.Compile(testCtx, baseSchema)
-		if err != nil {
-			fmt.Printf("Base schema compilation failed: %v\n", err)
-		} else {
-			fmt.Printf("Base schema compiled successfully to: %T\n", baseValidator)
-
-			// Test the base validator
-			testValues := []any{"string", 123, true, map[string]any{"key": "value"}}
-			for _, value := range testValues {
-				_, err := baseValidator.Validate(testCtx, value)
-				fmt.Printf("Base validator - Value %T: %v\n", value, err == nil)
-			}
-
-			// Debug: Check which allOf compilation path will be taken
-			fmt.Printf("Checking allOf compilation path...\n")
-			fmt.Printf("metaSchema.HasAllOf(): %v\n", metaSchema.HasAllOf())
-			fmt.Printf("hasBaseConstraints(metaSchema): %v\n", len(metaSchema.Types()) > 0) // This is what hasBaseConstraints checks for types
-
-			// Check if it has unevaluated fields that would trigger special handling
-			hasUnevaluatedProperties := metaSchema.HasUnevaluatedProperties()
-			hasUnevaluatedItems := metaSchema.HasUnevaluatedItems()
-			fmt.Printf("metaSchema.HasUnevaluatedProperties(): %v\n", hasUnevaluatedProperties)
-			fmt.Printf("metaSchema.HasUnevaluatedItems(): %v\n", hasUnevaluatedItems)
-		}
-	} else {
-		fmt.Printf("Meta-schema has NO types field!\n")
-	}
-
-	// Compile the meta-schema to a validator
-	ctx := context.Background()
-
-	// Set up vocabulary context for JSON Schema 2020-12
-	// Use AllEnabled to ensure all vocabularies are enabled for meta-schema compilation
-	vocabSet := vocabulary.AllEnabled()
-	ctx = vocabulary.WithSet(ctx, vocabSet)
-
-	// Set up resolver for meta-schema references
+	// Register every embedded document so the meta-schema's cross-vocabulary
+	// $refs (e.g. "meta/core") resolve from memory instead of over the network.
 	resolver := schema.NewResolver()
+	docs, err := loadEmbeddedSchemas()
+	if err != nil {
+		return err
+	}
+	for uri, doc := range docs {
+		resolver.RegisterDocument(uri, doc)
+	}
+
+	root := docs[rootRef]
+	if root == nil {
+		return fmt.Errorf("root meta-schema %q not found in embedded schemas", rootRef)
+	}
+
+	ctx := context.Background()
+	// Enable all vocabularies so the meta-schema compiles with every keyword it
+	// uses across the core/applicator/validation/etc. vocabularies.
+	ctx = vocabulary.WithSet(ctx, vocabulary.AllEnabled())
 	ctx = schema.WithResolver(ctx, resolver)
+	ctx = schema.WithBaseSchema(ctx, root)
+	ctx = schema.WithBaseURI(ctx, baseURI)
 
-	// Set up base schema context for reference resolution
-	ctx = schema.WithBaseSchema(ctx, &metaSchema)
-
-	// Set up base URI for relative reference resolution within metaschema
-	// Use the directory base URI, not the specific schema file URI
-	// This allows meta/core to resolve to https://json-schema.org/draft/2020-12/meta/core
-	ctx = schema.WithBaseURI(ctx, "https://json-schema.org/draft/2020-12/")
-
-	// Compile the meta-schema to a validator
-	compiledValidator, err := validator.Compile(ctx, &metaSchema)
+	compiledValidator, err := validator.Compile(ctx, root)
 	if err != nil {
 		return fmt.Errorf("failed to compile meta-schema: %w", err)
 	}
 
-	fmt.Printf("Successfully compiled meta-schema to validator of type: %T\n", compiledValidator)
-
-	// Debug: Print the structure of the compiled validator
-	debugValidator(compiledValidator, 0)
-
-	// Use the code generator to generate the builder chain
-	generator := validator.NewCodeGenerator()
 	var builderBuf bytes.Buffer
-
-	err = generator.Generate(&builderBuf, compiledValidator)
-	if err != nil {
+	if err := validator.NewCodeGenerator().Generate(&builderBuf, compiledValidator); err != nil {
 		return fmt.Errorf("failed to generate validator code: %w", err)
 	}
 
-	builderChain := builderBuf.String()
-	fmt.Printf("Generated builder chain: %s\n", builderChain)
-
-	// Create the package content using the generated builder chain
 	packageContent := fmt.Sprintf(`// Code generated by internal/cmd/genmeta. DO NOT EDIT.
 
 // Package meta provides a pre-compiled validator for JSON Schema 2020-12 meta-schema.
@@ -155,7 +90,6 @@ func _main() error {
 package meta
 
 import (
-	"context"
 	"github.com/lestrrat-go/json-schema/keywords"
 	"github.com/lestrrat-go/json-schema/validator"
 )
@@ -172,34 +106,8 @@ func init() {
 	// Generated validator using the code generator from the actual meta-schema
 	metaValidator = %s
 }
+`, builderBuf.String())
 
-// Validator returns a pre-compiled validator for the JSON Schema 2020-12 meta-schema.
-// This validator can be used to validate JSON Schema documents themselves.
-//
-// Example usage:
-//
-//	validator := meta.Validator()
-//	result, err := validator.Validate(ctx, jsonSchemaDocument)
-func Validator() validator.Interface {
-	return metaValidator
-}
-
-// Validate validates a JSON Schema document against the JSON Schema 2020-12 meta-schema.
-// This is a convenience function that uses the pre-compiled validator.
-//
-// Example usage:
-//
-//	err := meta.Validate(ctx, jsonSchemaDocument)
-//	if err != nil {
-//	    // The document is not a valid JSON Schema
-//	}
-func Validate(ctx context.Context, jsonSchemaDocument any) error {
-	_, err := metaValidator.Validate(ctx, jsonSchemaDocument)
-	return err
-}
-`, builderChain)
-
-	// Format the generated code
 	formattedCode, err := format.Source([]byte(packageContent))
 	if err != nil {
 		scanner := bufio.NewScanner(strings.NewReader(packageContent))
@@ -211,15 +119,8 @@ func Validate(ctx context.Context, jsonSchemaDocument any) error {
 		return fmt.Errorf("failed to format generated code: %w", err)
 	}
 
-	// Ensure meta directory exists
-	metaDir := filepath.Join(rootDir, "meta")
-	if err := os.MkdirAll(metaDir, 0755); err != nil {
-		return fmt.Errorf("failed to create meta directory: %w", err)
-	}
-
-	// Write the generated code to meta/meta_gen.go
-	outputPath := filepath.Join(metaDir, "meta_gen.go")
-	if err := os.WriteFile(outputPath, formattedCode, 0644); err != nil {
+	outputPath := filepath.Join(rootDir, "meta", "meta_gen.go")
+	if err := os.WriteFile(outputPath, formattedCode, 0o644); err != nil {
 		return fmt.Errorf("failed to write generated code to %q: %w", outputPath, err)
 	}
 
@@ -227,9 +128,39 @@ func Validate(ctx context.Context, jsonSchemaDocument any) error {
 	return nil
 }
 
+// loadEmbeddedSchemas parses every JSON document under schemaRoot and keys it by
+// its canonical retrieval URI (baseURI joined with the path relative to
+// schemaRoot, sans ".json" extension).
+func loadEmbeddedSchemas() (map[string]*schema.Schema, error) {
+	docs := make(map[string]*schema.Schema)
+	err := fs.WalkDir(schemaFS, schemaRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".json") {
+			return nil
+		}
+		data, err := schemaFS.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read embedded schema %q: %w", path, err)
+		}
+		var s schema.Schema
+		if err := s.UnmarshalJSON(data); err != nil {
+			return fmt.Errorf("failed to unmarshal embedded schema %q: %w", path, err)
+		}
+		rel := strings.TrimPrefix(path, schemaRoot+"/")
+		uri := baseURI + strings.TrimSuffix(rel, ".json")
+		docs[uri] = &s
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return docs, nil
+}
+
 // findRootDir finds the root directory containing the main go.mod file
 func findRootDir() (string, error) {
-	// Start from current directory and walk up until we find go.mod
 	dir, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -238,10 +169,10 @@ func findRootDir() (string, error) {
 	for {
 		goModPath := filepath.Join(dir, "go.mod")
 		if _, err := os.Stat(goModPath); err == nil {
-			// Check if this is the main go.mod (contains github.com/lestrrat-go/json-schema)
 			content, err := os.ReadFile(goModPath)
 			if err == nil && len(content) > 0 {
-				// Simple check - if it doesn't contain "replace", it's likely the main module
+				// The main module's go.mod has no replace directive pointing the
+				// module at itself (only the generator sub-modules do).
 				if !bytes.Contains(content, []byte("replace github.com/lestrrat-go/json-schema")) {
 					return dir, nil
 				}
@@ -250,108 +181,10 @@ func findRootDir() (string, error) {
 
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			break // reached root
+			break
 		}
 		dir = parent
 	}
 
 	return "", fmt.Errorf("could not find root go.mod file")
-}
-
-// debugValidator recursively prints the structure of validators to help debug what's being compiled
-func debugValidator(v validator.Interface, depth int) {
-	if v == nil {
-		return
-	}
-
-	if depth > 10 {
-		fmt.Printf("%s... (max depth reached)\n", strings.Repeat("  ", depth))
-		return
-	}
-
-	indent := strings.Repeat("  ", depth)
-	vType := reflect.TypeOf(v)
-	if vType.Kind() == reflect.Ptr {
-		vType = vType.Elem()
-	}
-
-	fmt.Printf("%s%s (%T)\n", indent, vType.Name(), v)
-
-	// Try to access the internal structure using reflection for known types
-	vValue := reflect.ValueOf(v)
-	if vValue.Kind() == reflect.Ptr {
-		vValue = vValue.Elem()
-	}
-
-	// Handle MultiValidator specifically
-	if vType.Name() == "MultiValidator" {
-		// Look for validators field
-		if vValue.IsValid() {
-			for i := 0; i < vValue.NumField(); i++ {
-				field := vValue.Field(i)
-				fieldType := vValue.Type().Field(i)
-
-				if fieldType.Name == "validators" && field.Kind() == reflect.Slice {
-					fmt.Printf("%s  %d validators:\n", indent, field.Len())
-					for j := 0; j < field.Len(); j++ {
-						child := field.Index(j)
-						if child.CanInterface() {
-							if childValidator, ok := child.Interface().(validator.Interface); ok {
-								debugValidator(childValidator, depth+2)
-							}
-						}
-					}
-				} else if fieldType.Name == "mode" {
-					fmt.Printf("%s  mode: %v\n", indent, field.Interface())
-				}
-			}
-		}
-	}
-
-	// Print all fields for other validator types to see their structure
-	if vType.Name() != "MultiValidator" && vValue.IsValid() {
-		for i := 0; i < vValue.NumField(); i++ {
-			field := vValue.Field(i)
-			fieldType := vValue.Type().Field(i)
-
-			// Skip unexported fields that might cause issues
-			if !fieldType.IsExported() {
-				continue
-			}
-
-			// Print field values for debugging
-			if field.CanInterface() {
-				switch field.Kind() {
-				case reflect.Slice:
-					fmt.Printf("%s  %s: [%d items]\n", indent, fieldType.Name, field.Len())
-					if field.Len() < 5 { // Only show details for small slices
-						for j := 0; j < field.Len(); j++ {
-							item := field.Index(j)
-							if item.CanInterface() {
-								fmt.Printf("%s    [%d]: %v\n", indent, j, item.Interface())
-							}
-						}
-					}
-				case reflect.Map:
-					fmt.Printf("%s  %s: map[%d entries]\n", indent, fieldType.Name, field.Len())
-					if field.Len() < 5 { // Only show details for small maps
-						for _, key := range field.MapKeys() {
-							value := field.MapIndex(key)
-							if key.CanInterface() && value.CanInterface() {
-								fmt.Printf("%s    %v: %v\n", indent, key.Interface(), value.Interface())
-							}
-						}
-					}
-				case reflect.Ptr:
-					if !field.IsNil() {
-						fmt.Printf("%s  %s: %v\n", indent, fieldType.Name, field.Interface())
-					} else {
-						fmt.Printf("%s  %s: nil\n", indent, fieldType.Name)
-					}
-				default:
-					fmt.Printf("%s  %s: %v\n", indent, fieldType.Name, field.Interface())
-				}
-			}
-		}
-	}
 }

--- a/internal/cmd/genmeta/schemas/2020-12/meta/applicator.json
+++ b/internal/cmd/genmeta/schemas/2020-12/meta/applicator.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/applicator",
+    "$dynamicAnchor": "meta",
+
+    "title": "Applicator vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "prefixItems": { "$ref": "#/$defs/schemaArray" },
+        "items": { "$dynamicRef": "#meta" },
+        "contains": { "$dynamicRef": "#meta" },
+        "additionalProperties": { "$dynamicRef": "#meta" },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependentSchemas": {
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" },
+            "default": {}
+        },
+        "propertyNames": { "$dynamicRef": "#meta" },
+        "if": { "$dynamicRef": "#meta" },
+        "then": { "$dynamicRef": "#meta" },
+        "else": { "$dynamicRef": "#meta" },
+        "allOf": { "$ref": "#/$defs/schemaArray" },
+        "anyOf": { "$ref": "#/$defs/schemaArray" },
+        "oneOf": { "$ref": "#/$defs/schemaArray" },
+        "not": { "$dynamicRef": "#meta" }
+    },
+    "$defs": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$dynamicRef": "#meta" }
+        }
+    }
+}

--- a/internal/cmd/genmeta/schemas/2020-12/meta/content.json
+++ b/internal/cmd/genmeta/schemas/2020-12/meta/content.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/content",
+    "$dynamicAnchor": "meta",
+
+    "title": "Content vocabulary meta-schema",
+
+    "type": ["object", "boolean"],
+    "properties": {
+        "contentEncoding": { "type": "string" },
+        "contentMediaType": { "type": "string" },
+        "contentSchema": { "$dynamicRef": "#meta" }
+    }
+}

--- a/internal/cmd/genmeta/schemas/2020-12/meta/core.json
+++ b/internal/cmd/genmeta/schemas/2020-12/meta/core.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/core",
+    "$dynamicAnchor": "meta",
+
+    "title": "Core vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "$ref": "#/$defs/uriReferenceString",
+            "$comment": "Non-empty fragments not allowed.",
+            "pattern": "^[^#]*#?$"
+        },
+        "$schema": { "$ref": "#/$defs/uriString" },
+        "$ref": { "$ref": "#/$defs/uriReferenceString" },
+        "$anchor": { "$ref": "#/$defs/anchorString" },
+        "$dynamicRef": { "$ref": "#/$defs/uriReferenceString" },
+        "$dynamicAnchor": { "$ref": "#/$defs/anchorString" },
+        "$vocabulary": {
+            "type": "object",
+            "propertyNames": { "$ref": "#/$defs/uriString" },
+            "additionalProperties": {
+                "type": "boolean"
+            }
+        },
+        "$comment": {
+            "type": "string"
+        },
+        "$defs": {
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" }
+        }
+    },
+    "$defs": {
+        "anchorString": {
+            "type": "string",
+            "pattern": "^[A-Za-z_][-A-Za-z0-9._]*$"
+        },
+        "uriString": {
+            "type": "string",
+            "format": "uri"
+        },
+        "uriReferenceString": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/internal/cmd/genmeta/schemas/2020-12/meta/format-annotation.json
+++ b/internal/cmd/genmeta/schemas/2020-12/meta/format-annotation.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/format-annotation",
+    "$dynamicAnchor": "meta",
+
+    "title": "Format vocabulary meta-schema for annotation results",
+    "type": ["object", "boolean"],
+    "properties": {
+        "format": { "type": "string" }
+    }
+}

--- a/internal/cmd/genmeta/schemas/2020-12/meta/format.json
+++ b/internal/cmd/genmeta/schemas/2020-12/meta/format.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/format-annotation",
+    "$dynamicAnchor": "meta",
+
+    "title": "Format vocabulary meta-schema for annotation results",
+    "type": ["object", "boolean"],
+    "properties": {
+        "format": { "type": "string" }
+    }
+}

--- a/internal/cmd/genmeta/schemas/2020-12/meta/meta-data.json
+++ b/internal/cmd/genmeta/schemas/2020-12/meta/meta-data.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/meta-data",
+    "$dynamicAnchor": "meta",
+
+    "title": "Meta-data vocabulary meta-schema",
+
+    "type": ["object", "boolean"],
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": true,
+        "deprecated": {
+            "type": "boolean",
+            "default": false
+        },
+        "readOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "writeOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "examples": {
+            "type": "array",
+            "items": true
+        }
+    }
+}

--- a/internal/cmd/genmeta/schemas/2020-12/meta/unevaluated.json
+++ b/internal/cmd/genmeta/schemas/2020-12/meta/unevaluated.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/unevaluated",
+    "$dynamicAnchor": "meta",
+
+    "title": "Unevaluated applicator vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "unevaluatedItems": { "$dynamicRef": "#meta" },
+        "unevaluatedProperties": { "$dynamicRef": "#meta" }
+    }
+}

--- a/internal/cmd/genmeta/schemas/2020-12/meta/validation.json
+++ b/internal/cmd/genmeta/schemas/2020-12/meta/validation.json
@@ -1,0 +1,95 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/validation",
+    "$dynamicAnchor": "meta",
+
+    "title": "Validation vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "type": {
+            "anyOf": [
+                { "$ref": "#/$defs/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "const": true,
+        "enum": {
+            "type": "array",
+            "items": true
+        },
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minLength": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "maxItems": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minItems": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxContains": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minContains": {
+            "$ref": "#/$defs/nonNegativeInteger",
+            "default": 1
+        },
+        "maxProperties": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/$defs/stringArray" },
+        "dependentRequired": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/stringArray"
+            }
+        }
+    },
+    "$defs": {
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "$ref": "#/$defs/nonNegativeInteger",
+            "default": 0
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    }
+}

--- a/internal/cmd/genmeta/schemas/2020-12/schema.json
+++ b/internal/cmd/genmeta/schemas/2020-12/schema.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+        "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+        "https://json-schema.org/draft/2020-12/vocab/validation": true,
+        "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+        "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+        "https://json-schema.org/draft/2020-12/vocab/content": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "Core and Validation specifications meta-schema",
+    "allOf": [
+        {"$ref": "meta/core"},
+        {"$ref": "meta/applicator"},
+        {"$ref": "meta/unevaluated"},
+        {"$ref": "meta/validation"},
+        {"$ref": "meta/meta-data"},
+        {"$ref": "meta/format-annotation"},
+        {"$ref": "meta/content"}
+    ],
+    "type": ["object", "boolean"],
+    "$comment": "This meta-schema also defines keywords that have appeared in previous drafts in order to prevent incompatible extensions as they remain in common use.",
+    "properties": {
+        "definitions": {
+            "$comment": "\"definitions\" has been replaced by \"$defs\".",
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" },
+            "deprecated": true,
+            "default": {}
+        },
+        "dependencies": {
+            "$comment": "\"dependencies\" has been split and replaced by \"dependentSchemas\" and \"dependentRequired\" in order to serve their differing semantics.",
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$dynamicRef": "#meta" },
+                    { "$ref": "meta/validation#/$defs/stringArray" }
+                ]
+            },
+            "deprecated": true,
+            "default": {}
+        },
+        "$recursiveAnchor": {
+            "$comment": "\"$recursiveAnchor\" has been replaced by \"$dynamicAnchor\".",
+            "$ref": "meta/core#/$defs/anchorString",
+            "deprecated": true
+        },
+        "$recursiveRef": {
+            "$comment": "\"$recursiveRef\" has been replaced by \"$dynamicRef\".",
+            "$ref": "meta/core#/$defs/uriReferenceString",
+            "deprecated": true
+        }
+    }
+}

--- a/internal/schemactx/context.go
+++ b/internal/schemactx/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 )
 
 type EvaluatedProperties struct {
@@ -328,9 +329,7 @@ func WithDynamicAnchorValidator(ctx context.Context, name string, v any) context
 	vctx := ValidationContextFrom(ctx)
 	newVctx := *vctx // copy
 	next := make(map[string]any, len(vctx.DynamicAnchorValidators)+1)
-	for k, val := range vctx.DynamicAnchorValidators {
-		next[k] = val
-	}
+	maps.Copy(next, vctx.DynamicAnchorValidators)
 	next[name] = v
 	newVctx.DynamicAnchorValidators = next
 	return WithValidationContext(ctx, &newVctx)

--- a/internal/schemactx/context.go
+++ b/internal/schemactx/context.go
@@ -101,6 +101,13 @@ type ValidationContext struct {
 	RefDepths      map[string]int // data depth at which each active reference was entered
 	DataDepth      int            // number of child-applying keyword boundaries crossed during compilation
 	Evaluation     *EvaluationContext
+	// DynamicAnchorValidators maps a $dynamicAnchor name to an already-compiled
+	// validator standing in for the outermost dynamic-scope resource declaring
+	// that anchor. It lets a precompiled validator (e.g. the generated meta
+	// validator) satisfy a $dynamicRef when no schema document is available to
+	// resolve against at runtime. Values are validator.Interface stored as any
+	// because the validator package cannot be imported here.
+	DynamicAnchorValidators map[string]any
 }
 
 // Context key for the consolidated validation context
@@ -312,6 +319,27 @@ func WithEvaluationContext(ctx context.Context, ec *EvaluationContext) context.C
 func EvaluationContextFromContext(ctx context.Context) (*EvaluationContext, error) {
 	vctx := ValidationContextFrom(ctx)
 	return valueFromContext[*EvaluationContext](vctx.Evaluation, vctx.Evaluation != nil, "evaluation context")
+}
+
+// WithDynamicAnchorValidator registers a compiled validator under a
+// $dynamicAnchor name. Registrations accumulate; the most recent registration
+// for a given name wins.
+func WithDynamicAnchorValidator(ctx context.Context, name string, v any) context.Context {
+	vctx := ValidationContextFrom(ctx)
+	newVctx := *vctx // copy
+	next := make(map[string]any, len(vctx.DynamicAnchorValidators)+1)
+	for k, val := range vctx.DynamicAnchorValidators {
+		next[k] = val
+	}
+	next[name] = v
+	newVctx.DynamicAnchorValidators = next
+	return WithValidationContext(ctx, &newVctx)
+}
+
+// DynamicAnchorValidatorFromContext returns the validator registered for the
+// given $dynamicAnchor name, or nil if none is registered.
+func DynamicAnchorValidatorFromContext(ctx context.Context, name string) any {
+	return ValidationContextFrom(ctx).DynamicAnchorValidators[name]
 }
 
 // Logging context functions

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -1,0 +1,53 @@
+package meta
+
+import (
+	"context"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+)
+
+// metaSchemaValidator wraps the generated meta validator so the
+// "$dynamicRef": "#meta" nodes inside it resolve back to the meta validator
+// itself.
+//
+// The 2020-12 meta-schema declares "$dynamicAnchor": "meta" at its root and
+// applies "$dynamicRef": "#meta" to every subschema, which means "this value
+// must itself be a valid schema". Since metaValidator embodies the whole
+// meta-schema, that recursion is simply re-entry into metaValidator. The
+// generated validator carries no schema document at runtime, so instead of
+// resolving the anchor against a document we register metaValidator under the
+// "meta" dynamic anchor and let DynamicReferenceValidator pick it up.
+type metaSchemaValidator struct{}
+
+func (metaSchemaValidator) Validate(ctx context.Context, v any) (validator.Result, error) {
+	ctx = schema.WithDynamicAnchorValidator(ctx, "meta", metaValidator)
+	return metaValidator.Validate(ctx, v)
+}
+
+// Validator returns a pre-compiled validator for the JSON Schema 2020-12
+// meta-schema. This validator can be used to validate JSON Schema documents
+// themselves.
+//
+// Example usage:
+//
+//	validator := meta.Validator()
+//	result, err := validator.Validate(ctx, jsonSchemaDocument)
+func Validator() validator.Interface {
+	return metaSchemaValidator{}
+}
+
+// Validate validates a JSON Schema document against the JSON Schema 2020-12
+// meta-schema. This is a convenience function that uses the pre-compiled
+// validator.
+//
+// Example usage:
+//
+//	err := meta.Validate(ctx, jsonSchemaDocument)
+//	if err != nil {
+//	    // The document is not a valid JSON Schema
+//	}
+func Validate(ctx context.Context, jsonSchemaDocument any) error {
+	_, err := Validator().Validate(ctx, jsonSchemaDocument)
+	return err
+}

--- a/meta/meta_gen.go
+++ b/meta/meta_gen.go
@@ -5,7 +5,6 @@
 package meta
 
 import (
-	"context"
 	"github.com/lestrrat-go/json-schema/keywords"
 	"github.com/lestrrat-go/json-schema/validator"
 )
@@ -504,29 +503,4 @@ func init() {
 					MustBuild(),
 			),
 		)
-}
-
-// Validator returns a pre-compiled validator for the JSON Schema 2020-12 meta-schema.
-// This validator can be used to validate JSON Schema documents themselves.
-//
-// Example usage:
-//
-//	validator := meta.Validator()
-//	result, err := validator.Validate(ctx, jsonSchemaDocument)
-func Validator() validator.Interface {
-	return metaValidator
-}
-
-// Validate validates a JSON Schema document against the JSON Schema 2020-12 meta-schema.
-// This is a convenience function that uses the pre-compiled validator.
-//
-// Example usage:
-//
-//	err := meta.Validate(ctx, jsonSchemaDocument)
-//	if err != nil {
-//	    // The document is not a valid JSON Schema
-//	}
-func Validate(ctx context.Context, jsonSchemaDocument any) error {
-	_, err := metaValidator.Validate(ctx, jsonSchemaDocument)
-	return err
 }

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -1,0 +1,70 @@
+package meta_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/json-schema/meta"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidate exercises the precompiled 2020-12 meta-schema validator,
+// including the "$dynamicRef": "#meta" recursion the meta-schema applies to
+// every subschema. That recursion resolves back into the meta validator itself
+// (it declares "$dynamicAnchor": "meta" at its root), so nested subschemas are
+// validated, not just the top level.
+//
+// Regression: validating an ordinary object-schema document used to panic with
+// a nil-pointer dereference because the "#meta" $dynamicRef had no schema
+// document to resolve against at runtime and a nil base schema was dereferenced
+// during anchor lookup.
+func TestValidate(t *testing.T) {
+	t.Run("ObjectSchemaDocument", func(t *testing.T) {
+		doc := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{"type": "string"},
+				"age":  map[string]any{"type": "integer", "minimum": 0},
+			},
+			"required": []any{"name"},
+		}
+
+		require.NotPanics(t, func() {
+			require.NoError(t, meta.Validate(t.Context(), doc),
+				"an ordinary object schema is a valid JSON Schema document")
+		})
+	})
+
+	t.Run("NestedSubschemaValidated", func(t *testing.T) {
+		// The inner {"type": 123} is not a valid schema ("type" must be a string
+		// or array of strings). It is only reachable through "$dynamicRef":
+		// "#meta", so rejecting it proves the dynamic reference recurses into the
+		// meta-schema rather than degrading to accept-everything.
+		doc := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"x": map[string]any{"type": float64(123)},
+			},
+		}
+
+		require.Error(t, meta.Validate(t.Context(), doc),
+			"a schema with a malformed nested subschema must be rejected")
+	})
+
+	t.Run("DeeplyNestedValidSchema", func(t *testing.T) {
+		doc := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"items": map[string]any{
+					"type":  "array",
+					"items": map[string]any{"type": "string", "minLength": float64(1)},
+				},
+			},
+		}
+
+		require.NoError(t, meta.Validate(t.Context(), doc))
+	})
+
+	t.Run("NonSchemaRejected", func(t *testing.T) {
+		require.Error(t, meta.Validate(t.Context(), "not a schema"))
+	})
+}

--- a/resolver.go
+++ b/resolver.go
@@ -208,6 +208,11 @@ func (r *Resolver) ResolveAnchor(ctx context.Context, dst *Schema, anchorName st
 	if err != nil {
 		return fmt.Errorf("no base schema provided in context for resolving anchor %s: %w", anchorName, err)
 	}
+	// A nil *Schema can be boxed into the context's any-typed slot and slip past
+	// the presence check above; guard against dereferencing it during the search.
+	if baseSchema == nil {
+		return fmt.Errorf("nil base schema in context for resolving anchor %s", anchorName)
+	}
 
 	anchorSchema, err := r.findSchemaByAnchor(baseSchema, anchorName)
 	if err != nil {

--- a/schema.go
+++ b/schema.go
@@ -262,6 +262,21 @@ func RootSchemaFromContext(ctx context.Context) *Schema {
 	return rootSchema
 }
 
+// WithDynamicAnchorValidator registers a compiled validator under a
+// $dynamicAnchor name so a $dynamicRef to that anchor can be satisfied at
+// validation time even when no schema document is available to resolve against
+// (e.g. the precompiled meta-schema validator). The value is an opaque
+// validator handle; the validator package asserts its concrete type.
+func WithDynamicAnchorValidator(ctx context.Context, name string, v any) context.Context {
+	return schemactx.WithDynamicAnchorValidator(ctx, name, v)
+}
+
+// DynamicAnchorValidatorFromContext returns the validator registered for the
+// given $dynamicAnchor name, or nil if none is registered.
+func DynamicAnchorValidatorFromContext(ctx context.Context, name string) any {
+	return schemactx.DynamicAnchorValidatorFromContext(ctx, name)
+}
+
 // WithBaseURI adds a base URI to the context for reference resolution
 func WithBaseURI(ctx context.Context, baseURI string) context.Context {
 	return schemactx.WithBaseURI(ctx, baseURI)

--- a/validator/codegen_core.go
+++ b/validator/codegen_core.go
@@ -70,6 +70,13 @@ func (g *codeGenerator) generateInternal(dst io.Writer, v Interface) error {
 		return g.generateInferredNumber(dst, validator)
 	case *IfThenElseValidator:
 		return g.generateIfThenElse(dst, validator)
+	case *dynamicScopeValidator:
+		// The dynamic-scope wrapper only records a schema resource on the runtime
+		// scope chain so $dynamicRef bookending can find it. Generated validators
+		// carry no schema document and resolve $dynamicRef via anchors registered
+		// in context (see schema.WithDynamicAnchorValidator), so emit the wrapped
+		// validator directly and drop the wrapper.
+		return g.generateInternal(dst, validator.inner)
 	default:
 		// Unsupported validator type, falling back to EmptyValidator
 		o.R("&validator.EmptyValidator{}")

--- a/validator/reference.go
+++ b/validator/reference.go
@@ -154,6 +154,18 @@ func NewDynamicReferenceValidator(reference string) *DynamicReferenceValidator {
 }
 
 func (dr *DynamicReferenceValidator) Validate(ctx context.Context, v any) (Result, error) {
+	// When the fragment is a plain $dynamicAnchor name and a validator has been
+	// registered for it in the context, the registered validator stands in for
+	// the outermost dynamic-scope resource declaring that anchor. This is how the
+	// precompiled meta-schema validator satisfies "$dynamicRef": "#meta" — it
+	// registers itself under "meta" and recurses, since no schema document is
+	// available to resolve against at validation time.
+	if name := plainAnchorFragment(dr.reference); name != "" {
+		if rv, ok := schema.DynamicAnchorValidatorFromContext(ctx, name).(Interface); ok && rv != nil {
+			return rv.Validate(ctx, v)
+		}
+	}
+
 	target, err := dr.resolveTarget(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("dynamic reference resolution failed for %s: %w", dr.reference, err)
@@ -247,6 +259,17 @@ func (dr *DynamicReferenceValidator) validatorFor(ctx context.Context, target *s
 	return v, nil
 }
 
+// plainAnchorFragment returns the fragment of ref when it is a plain anchor name
+// (e.g. "meta" for "#meta" or "extended#meta"), or "" when the reference has no
+// fragment or the fragment is a JSON pointer.
+func plainAnchorFragment(ref string) string {
+	_, frag, found := strings.Cut(ref, "#")
+	if !found || frag == "" || strings.HasPrefix(frag, "/") {
+		return ""
+	}
+	return frag
+}
+
 // resolveDynamicRef resolves a $dynamicRef. It first resolves the reference the
 // way $ref would (the "lexical" target). When the reference's fragment is a
 // plain anchor (e.g. "#meta" or "extended#meta") and that lexical target itself
@@ -255,19 +278,20 @@ func (dr *DynamicReferenceValidator) validatorFor(ctx context.Context, target *s
 // resource of the runtime dynamic scope. Otherwise it behaves exactly like $ref.
 func resolveDynamicRef(ctx context.Context, resolver *schema.Resolver, baseSchema *schema.Schema, dynamicRef string) (*schema.Schema, error) {
 	baseURI := schema.BaseURIFromContext(ctx)
-	refCtx := schema.WithBaseSchema(ctx, baseSchema)
+	// Only seed the base schema when one is actually available. A nil *Schema
+	// boxed into the context's any-typed slot would defeat the presence check in
+	// BaseSchemaFromContext and get dereferenced during anchor lookup.
+	refCtx := ctx
+	if baseSchema != nil {
+		refCtx = schema.WithBaseSchema(refCtx, baseSchema)
+	}
 	if baseURI != "" {
 		refCtx = schema.WithBaseURI(refCtx, baseURI)
 	}
 
 	// Determine whether the fragment is a plain anchor name (eligible for
 	// dynamic-scope bookending) versus a JSON pointer or no fragment at all.
-	var anchorName string
-	if _, frag, found := strings.Cut(dynamicRef, "#"); found {
-		if frag != "" && !strings.HasPrefix(frag, "/") {
-			anchorName = frag
-		}
-	}
+	anchorName := plainAnchorFragment(dynamicRef)
 
 	// Resolve the lexical target as $ref would.
 	var lexical schema.Schema


### PR DESCRIPTION
- `meta.Validate` no longer panics; `#meta` $dynamicRef resolves to the meta validator via a context dynamic-anchor registry, so nested subschemas are validated (not accept-all)
- guard nil base schema in `resolveDynamicRef` and `ResolveAnchor` so a boxed-nil base can't be dereferenced
- code generator handles `dynamicScopeValidator`; `genmeta` now regenerates `meta/meta_gen.go` offline from embedded 2020-12 inputs (no network)
- CI: `go generate ./...` + `git diff` gate to catch divergence between generators and committed output