### PR TITLE
use go.mod version in CI instead of go matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.24', '1.23' ]
-    name: "Test [ Go ${{ matrix.go }} ]"
+    name: "Test"
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -62,7 +59,7 @@ jobs:
       - name: Install Go stable version
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: "go.mod"
           check-latest: true
-      - name: Test 
+      - name: Test
         run: go test ./...

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,10 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.24', '1.23' ]
-    name: "Smoke [ Go ${{ matrix.go }} ]"
+    name: "Smoke"
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -48,7 +45,7 @@ jobs:
       - name: Install Go stable version
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: "go.mod"
           check-latest: true
       - name: Run smoke tests
         run: go test -short ./...


### PR DESCRIPTION
- Drop the `go: ['1.24','1.23']` matrix from `ci.yml` and `smoke.yml`; each runs a single job using `setup-go` with `go-version-file: "go.mod"`
- `go.mod` requires `go 1.24.4`, so the 1.23 entry could never satisfy it — under setup-go v5 it silently downloaded 1.24.x (fake "1.23" coverage); setup-go v6 (`GOTOOLCHAIN=local`) surfaced this as a hard failure (see #28)
- The Go version is now sourced from `go.mod`, the single source of truth — unblocks the setup-go v6 bump in #28
