### PR TITLE
exclude AGENTS.md and CLAUDE.md from autodoc

### DIFF
--- a/.github/workflows/autodoc.yml
+++ b/.github/workflows/autodoc.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Process markdown files
         run: |
-          find . -name '*.md' | xargs perl tools/autodoc.pl
+          find . -name '*.md' -not -name 'AGENTS.md' -not -name 'CLAUDE.md' -not -path './examples/*' | xargs perl tools/autodoc.pl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check documentation generator
         run: |
-          find . -name '*.md' | xargs env AUTODOC_DRYRUN=1 perl tools/autodoc.pl
+          find . -name '*.md' -not -name 'AGENTS.md' -not -name 'CLAUDE.md' -not -path './examples/*' | xargs env AUTODOC_DRYRUN=1 perl tools/autodoc.pl
       - name: Cache testdata
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:


### PR DESCRIPTION
- autodoc followed the `CLAUDE.md` symlink and rewrote it as a regular file on every merge (PR #32)
- exclude `AGENTS.md`, `CLAUDE.md`, and `examples/` from the `find` in both `autodoc.yml` and `smoke.yml`, matching the jwx repo
