### PR TITLE
back docs code with executable example tests

### DIFF
--- a/docs/00-getting-started.md
+++ b/docs/00-getting-started.md
@@ -24,48 +24,58 @@ Working with this library is always three steps:
 2. **Compile** it into a validator with `validator.Compile`.
 3. **Validate** data with `Interface.Validate`.
 
+<!-- INCLUDE(examples/doc_quickstart_test.go) -->
 ```go
-package main
+package examples_test
 
 import (
-	"context"
-	"fmt"
+  "context"
+  "fmt"
 
-	schema "github.com/lestrrat-go/json-schema"
-	"github.com/lestrrat-go/json-schema/validator"
+  schema "github.com/lestrrat-go/json-schema"
+  "github.com/lestrrat-go/json-schema/validator"
 )
 
-func main() {
-	ctx := context.Background()
+// Example_docQuickStart shows the three core steps: build a schema, compile it
+// into a validator, and validate data. A compiled validator is reusable across
+// many Validate calls and safe for concurrent use.
+func Example_docQuickStart() {
+  ctx := context.Background()
 
-	// 1. Build a schema.
-	s := schema.NewBuilder().
-		Schema(schema.Version).
-		Types(schema.ObjectType).
-		Property("name", schema.NonEmptyString().MustBuild()).
-		Property("email", schema.Email().MustBuild()).
-		Property("age", schema.PositiveInteger().MustBuild()).
-		Required("name", "email").
-		MustBuild()
+  // 1. Build a schema.
+  s := schema.NewBuilder().
+    Schema(schema.Version).
+    Types(schema.ObjectType).
+    Property("name", schema.NonEmptyString().MustBuild()).
+    Property("email", schema.Email().MustBuild()).
+    Property("age", schema.PositiveInteger().MustBuild()).
+    Required("name", "email").
+    MustBuild()
 
-	// 2. Compile it into a validator.
-	v, err := validator.Compile(ctx, s)
-	if err != nil {
-		panic(err)
-	}
+  // 2. Compile it into a validator.
+  v, err := validator.Compile(ctx, s)
+  if err != nil {
+    fmt.Println("compile failed:", err)
+    return
+  }
 
-	// 3. Validate data.
-	_, err = v.Validate(ctx, map[string]any{
-		"name":  "Ada Lovelace",
-		"email": "ada@example.com",
-		"age":   36,
-	})
-	fmt.Println("valid:", err == nil)
+  // 3. Validate data.
+  _, err = v.Validate(ctx, map[string]any{
+    "name":  "Ada Lovelace",
+    "email": "ada@example.com",
+    "age":   36,
+  })
+  fmt.Println("valid record:", err == nil)
 
-	_, err = v.Validate(ctx, map[string]any{"name": "", "email": "nope"})
-	fmt.Println("valid:", err == nil) // false
+  _, err = v.Validate(ctx, map[string]any{"name": "", "email": "x"})
+  fmt.Println("empty name:  ", err == nil)
+  // Output:
+  // valid record: true
+  // empty name:   false
 }
 ```
+source: [examples/doc_quickstart_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/doc_quickstart_test.go)
+<!-- END INCLUDE -->
 
 ## Why compile?
 

--- a/docs/01-building-schemas.md
+++ b/docs/01-building-schemas.md
@@ -4,31 +4,69 @@ A `*schema.Schema` is inert data. You can produce one two ways — programmatica
 
 ## The fluent builder
 
-`schema.NewBuilder()` returns a `*Builder` with one chainable method per JSON Schema keyword. Finish with `Build() (*Schema, error)` or `MustBuild() *Schema` (panics on error).
+`schema.NewBuilder()` returns a `*Builder` with one chainable method per JSON Schema keyword. Finish with `Build() (*Schema, error)` or `MustBuild() *Schema` (panics on error). The example below builds an object schema and marshals it back to JSON:
 
+<!-- INCLUDE(examples/doc_builder_test.go) -->
 ```go
-s := schema.NewBuilder().
-	Schema(schema.Version).                 // $schema: the 2020-12 dialect URI
-	ID("https://example.com/user").         // $id
-	Types(schema.ObjectType).               // type: object
-	Property("name", schema.NewBuilder().Types(schema.StringType).MinLength(1).MustBuild()).
-	Property("age", schema.NewBuilder().Types(schema.IntegerType).Minimum(0).MustBuild()).
-	Required("name").
-	AdditionalProperties(schema.FalseSchema()).
-	MustBuild()
+package examples_test
+
+import (
+  "encoding/json"
+  "fmt"
+  "os"
+
+  schema "github.com/lestrrat-go/json-schema"
+)
+
+// Example_docBuilder builds an object schema with the fluent builder and marshals
+// it to JSON. Object keys are emitted in a stable, sorted order, so the result is
+// deterministic and round-trips cleanly.
+func Example_docBuilder() {
+  s := schema.NewBuilder().
+    Schema(schema.Version).
+    ID("https://example.com/user").
+    Types(schema.ObjectType).
+    Property("name", schema.NewBuilder().Types(schema.StringType).MinLength(1).MustBuild()).
+    Property("age", schema.NewBuilder().Types(schema.IntegerType).Minimum(0).MustBuild()).
+    Required("name").
+    AdditionalProperties(schema.FalseSchema()).
+    MustBuild()
+
+  enc := json.NewEncoder(os.Stdout)
+  enc.SetIndent("", "  ")
+  if err := enc.Encode(s); err != nil {
+    fmt.Println("encode failed:", err)
+  }
+  // Output:
+  // {
+  //   "$id": "https://example.com/user",
+  //   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  //   "additionalProperties": false,
+  //   "properties": {
+  //     "age": {
+  //       "minimum": 0,
+  //       "type": "integer"
+  //     },
+  //     "name": {
+  //       "minLength": 1,
+  //       "type": "string"
+  //     }
+  //   },
+  //   "required": [
+  //     "name"
+  //   ],
+  //   "type": "object"
+  // }
+}
 ```
+source: [examples/doc_builder_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/doc_builder_test.go)
+<!-- END INCLUDE -->
 
 `schema.Version` is the constant `"https://json-schema.org/draft/2020-12/schema"`.
 
 ### Types
 
-`Types` is variadic and takes `PrimitiveType` constants — a schema may permit more than one type:
-
-```go
-schema.NewBuilder().Types(schema.StringType, schema.NullType).MustBuild()
-```
-
-The constants are `NullType`, `BooleanType`, `IntegerType`, `NumberType`, `StringType`, `ArrayType`, `ObjectType`.
+`Types` is variadic and takes `PrimitiveType` constants — a schema may permit more than one type, e.g. `Types(schema.StringType, schema.NullType)` for a string-or-null. The constants are `NullType`, `BooleanType`, `IntegerType`, `NumberType`, `StringType`, `ArrayType`, `ObjectType`.
 
 ### Keyword coverage
 
@@ -51,14 +89,7 @@ Every keyword method has a matching `ResetXxx()` that clears it.
 
 ### Boolean schemas
 
-JSON Schema allows `true` and `false` as whole schemas (accept-anything / reject-everything). Use `schema.TrueSchema()` and `schema.FalseSchema()` wherever a sub-schema is accepted:
-
-```go
-schema.NewBuilder().
-	Types(schema.ObjectType).
-	AdditionalProperties(schema.FalseSchema()). // forbid unlisted properties
-	MustBuild()
-```
+JSON Schema allows `true` and `false` as whole schemas (accept-anything / reject-everything). Use `schema.TrueSchema()` and `schema.FalseSchema()` wherever a sub-schema is accepted — for example `AdditionalProperties(schema.FalseSchema())` forbids unlisted properties (as in the builder example above).
 
 ## Convenience constructors
 
@@ -78,46 +109,106 @@ For common shapes, the package ships one-line constructors that each return a pr
 | `schema.OneOf(...)` / `AnyOf(...)` / `AllOf(...)` | composition over the given `*Schema`s |
 | `schema.Optional(s)` | accepts `s` **or** `null` |
 
+<!-- INCLUDE(examples/doc_convenience_test.go) -->
 ```go
-s := schema.NewBuilder().
-	Types(schema.ObjectType).
-	Property("id", schema.PositiveInteger().MustBuild()).
-	Property("nickname", schema.Optional(schema.NonEmptyString().MustBuild()).MustBuild()).
-	Property("role", schema.Enum("admin", "user").MustBuild()).
-	Required("id", "role").
-	MustBuild()
+package examples_test
+
+import (
+  "context"
+  "fmt"
+
+  schema "github.com/lestrrat-go/json-schema"
+  "github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_docConvenience composes several one-line convenience constructors —
+// PositiveInteger, Optional, NonEmptyString and Enum — into one object schema.
+// Optional(s) accepts either s or null.
+func Example_docConvenience() {
+  s := schema.NewBuilder().
+    Types(schema.ObjectType).
+    Property("id", schema.PositiveInteger().MustBuild()).
+    Property("nickname", schema.Optional(schema.NonEmptyString().MustBuild()).MustBuild()).
+    Property("role", schema.Enum("admin", "user").MustBuild()).
+    Required("id", "role").
+    MustBuild()
+
+  ctx := context.Background()
+  v, _ := validator.Compile(ctx, s)
+  check := func(data map[string]any) bool {
+    _, err := v.Validate(ctx, data)
+    return err == nil
+  }
+
+  fmt.Println("admin:        ", check(map[string]any{"id": 1, "role": "admin"}))
+  fmt.Println("null nickname:", check(map[string]any{"id": 1, "role": "user", "nickname": nil}))
+  fmt.Println("bad role:     ", check(map[string]any{"id": 1, "role": "root"}))
+  // Output:
+  // admin:         true
+  // null nickname: true
+  // bad role:      false
+}
 ```
+source: [examples/doc_convenience_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/doc_convenience_test.go)
+<!-- END INCLUDE -->
 
 > Note: `format` keywords (from `Email()`, `UUID()`, etc.) are **annotations by default** and do not reject bad values until you enable format-assertion. See [Vocabularies](./04-vocabularies-and-meta-schema.md).
 
 ## Loading a schema from JSON
 
-`*schema.Schema` implements `json.Unmarshaler`, so loading is just `json.Unmarshal`:
+`*schema.Schema` implements `json.Unmarshaler`, so loading is just `json.Unmarshal`. A schema built programmatically and the equivalent schema loaded from JSON are interchangeable — they compile and validate identically:
 
+<!-- INCLUDE(examples/doc_loadjson_test.go) -->
 ```go
-func loadSchema(path string) *schema.Schema {
-	buf, err := os.ReadFile(path)
-	if err != nil {
-		panic(err)
-	}
-	var s schema.Schema
-	if err := json.Unmarshal(buf, &s); err != nil {
-		panic(err)
-	}
-	return &s
+package examples_test
+
+import (
+  "context"
+  "encoding/json"
+  "fmt"
+
+  schema "github.com/lestrrat-go/json-schema"
+  "github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_docLoadJSON loads a schema authored as JSON. *schema.Schema implements
+// json.Unmarshaler, so json.Unmarshal is all it takes; the result compiles and
+// validates exactly like a schema built with the fluent builder.
+func Example_docLoadJSON() {
+  const doc = `{
+    "type": "object",
+    "properties": { "city": { "type": "string", "minLength": 1 } },
+    "required": ["city"]
+  }`
+
+  var s schema.Schema
+  if err := json.Unmarshal([]byte(doc), &s); err != nil {
+    fmt.Println("parse failed:", err)
+    return
+  }
+
+  ctx := context.Background()
+  v, err := validator.Compile(ctx, &s)
+  if err != nil {
+    fmt.Println("compile failed:", err)
+    return
+  }
+
+  _, err = v.Validate(ctx, map[string]any{"city": "Kyoto"})
+  fmt.Println("with city:   ", err == nil)
+  _, err = v.Validate(ctx, map[string]any{})
+  fmt.Println("without city:", err == nil)
+  // Output:
+  // with city:    true
+  // without city: false
 }
 ```
-
-A schema built programmatically and the equivalent schema loaded from JSON are interchangeable — they compile and validate identically.
+source: [examples/doc_loadjson_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/doc_loadjson_test.go)
+<!-- END INCLUDE -->
 
 ## Serializing a schema
 
-`*schema.Schema` also implements `json.Marshaler`. Object keys are emitted in a stable, sorted order, so marshaling is deterministic and round-trips cleanly:
-
-```go
-buf, _ := json.Marshal(s)
-// {"$id":"...","$schema":"...","properties":{...},"required":[...],"type":"object"}
-```
+`*schema.Schema` also implements `json.Marshaler`. Object keys are emitted in a stable, sorted order, so marshaling is deterministic and round-trips cleanly — the [fluent builder example](#the-fluent-builder) above marshals a schema and shows the resulting JSON.
 
 ## Next
 

--- a/docs/02-validating.md
+++ b/docs/02-validating.md
@@ -4,18 +4,7 @@ Validation is two steps: **compile** a schema into a validator, then **validate*
 
 ## Compile once, validate many
 
-```go
-import "github.com/lestrrat-go/json-schema/validator"
-
-v, err := validator.Compile(ctx, s) // s is a *schema.Schema
-if err != nil {
-	// the schema itself is invalid / cannot be compiled
-}
-
-result, err := v.Validate(ctx, data)
-```
-
-`Compile` returns a `validator.Interface`. Compiling walks the schema once and is the expensive step; the returned validator is safe to **reuse across goroutines** and across many `Validate` calls. Do the compile at startup, keep the `Interface` around, and call `Validate` per request.
+`validator.Compile(ctx, s)` returns a `validator.Interface`. Compiling walks the schema once and is the expensive step; the returned validator is safe to **reuse across goroutines** and across many `Validate` calls. Do the compile at startup, keep the `Interface` around, and call `Validate(ctx, data)` per request.
 
 `data` is any decoded JSON value — `map[string]any`, `[]any`, `string`, `float64`, `bool`, `nil`, etc. (the shapes `encoding/json` produces into an `any`).
 
@@ -24,42 +13,57 @@ result, err := v.Validate(ctx, data)
 `Validate` returns `(Result, error)`:
 
 - **`error == nil`** → the data is valid.
-- **`error != nil`** → validation failed; the error describes what and where.
-
-```go
-if _, err := v.Validate(ctx, data); err != nil {
-	fmt.Println("invalid:", err)
-	// invalid: ... property validation failed for name: ... string length (0) shorter then minLength (1)
-}
-```
+- **`error != nil`** → validation failed; the error describes what and where (e.g. `property validation failed for name: ... string length (0) shorter then minLength (1)`).
 
 The `Result` value carries validation annotations (chiefly which properties/items were evaluated, used internally for `unevaluatedProperties`/`unevaluatedItems`). Most callers only need the error.
 
 ## A complete example
 
+Compile once, then validate several inputs against the reused validator:
+
+<!-- INCLUDE(examples/doc_validate_test.go) -->
 ```go
-ctx := context.Background()
+package examples_test
 
-s := schema.NewBuilder().
-	Types(schema.ObjectType).
-	Property("id", schema.PositiveInteger().MustBuild()).
-	Property("role", schema.Enum("admin", "user").MustBuild()).
-	Required("id", "role").
-	MustBuild()
+import (
+  "context"
+  "fmt"
 
-v, err := validator.Compile(ctx, s)
-if err != nil {
-	panic(err)
-}
+  schema "github.com/lestrrat-go/json-schema"
+  "github.com/lestrrat-go/json-schema/validator"
+)
 
-for _, data := range []map[string]any{
-	{"id": 1, "role": "admin"}, // valid
-	{"id": 1, "role": "root"},  // invalid: role not in enum
-} {
-	_, err := v.Validate(ctx, data)
-	fmt.Printf("valid=%t\n", err == nil)
+// Example_docValidate compiles a schema once and reuses the validator for several
+// inputs. Validate returns a non-nil error when the data is invalid.
+func Example_docValidate() {
+  s := schema.NewBuilder().
+    Types(schema.ObjectType).
+    Property("id", schema.PositiveInteger().MustBuild()).
+    Property("role", schema.Enum("admin", "user").MustBuild()).
+    Required("id", "role").
+    MustBuild()
+
+  ctx := context.Background()
+  v, err := validator.Compile(ctx, s)
+  if err != nil {
+    fmt.Println("compile failed:", err)
+    return
+  }
+
+  for _, data := range []map[string]any{
+    {"id": 1, "role": "admin"}, // valid
+    {"id": 1, "role": "root"},  // role not in enum
+  } {
+    _, err := v.Validate(ctx, data)
+    fmt.Printf("valid=%t\n", err == nil)
+  }
+  // Output:
+  // valid=true
+  // valid=false
 }
 ```
+source: [examples/doc_validate_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/doc_validate_test.go)
+<!-- END INCLUDE -->
 
 ## Pass the same context to Compile and Validate
 
@@ -77,19 +81,50 @@ By default the validator follows the JSON Schema 2020-12 default: `format` is an
 
 ## Tracing
 
-When an error message alone does not make it obvious *why* an input was rejected, attach a structured trace logger before compiling and validating:
+When an error message alone does not make it obvious *why* an input was rejected, attach a structured trace logger with `validator.WithTraceSlog` before compiling and validating. The trace shows which keyword and branch each value hit — the fastest way to debug a failing `anyOf`, `if/then/else`, or a deep nested property. (Point the handler at `os.Stderr` in real use; the example discards it for deterministic output.)
 
+<!-- INCLUDE(examples/doc_tracing_test.go) -->
 ```go
-import "log/slog"
+package examples_test
 
-logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-ctx := validator.WithTraceSlog(context.Background(), logger)
+import (
+  "context"
+  "fmt"
+  "io"
+  "log/slog"
 
-v, _ := validator.Compile(ctx, s)
-_, err := v.Validate(ctx, data) // emits a step-by-step trace of the validation walk
+  schema "github.com/lestrrat-go/json-schema"
+  "github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_docTracing attaches a structured trace logger with WithTraceSlog. The
+// logger records the validation walk keyword by keyword, which is the fastest way
+// to see why an input was rejected. In real use point the handler at os.Stderr;
+// here it is discarded so the example output stays deterministic.
+func Example_docTracing() {
+  s := schema.NewBuilder().
+    Types(schema.ObjectType).
+    Property("id", schema.PositiveInteger().MustBuild()).
+    Required("id").
+    MustBuild()
+
+  logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+  ctx := validator.WithTraceSlog(context.Background(), logger)
+
+  v, err := validator.Compile(ctx, s)
+  if err != nil {
+    fmt.Println("compile failed:", err)
+    return
+  }
+
+  _, err = v.Validate(ctx, map[string]any{"id": 1})
+  fmt.Println("valid:", err == nil)
+  // Output:
+  // valid: true
+}
 ```
-
-The trace shows which keyword and branch each value hit, which is the fastest way to debug a failing `anyOf`, `if/then/else`, or a deep nested property.
+source: [examples/doc_tracing_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/doc_tracing_test.go)
+<!-- END INCLUDE -->
 
 ## Next
 

--- a/docs/02-validating.md
+++ b/docs/02-validating.md
@@ -88,9 +88,9 @@ When an error message alone does not make it obvious *why* an input was rejected
 package examples_test
 
 import (
+  "bytes"
   "context"
   "fmt"
-  "io"
   "log/slog"
 
   schema "github.com/lestrrat-go/json-schema"
@@ -100,7 +100,8 @@ import (
 // Example_docTracing attaches a structured trace logger with WithTraceSlog. The
 // logger records the validation walk keyword by keyword, which is the fastest way
 // to see why an input was rejected. In real use point the handler at os.Stderr;
-// here it is discarded so the example output stays deterministic.
+// here it writes to a buffer that is never printed, so the example output stays
+// deterministic.
 func Example_docTracing() {
   s := schema.NewBuilder().
     Types(schema.ObjectType).
@@ -108,7 +109,8 @@ func Example_docTracing() {
     Required("id").
     MustBuild()
 
-  logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+  var traceOut bytes.Buffer
+  logger := slog.New(slog.NewTextHandler(&traceOut, &slog.HandlerOptions{Level: slog.LevelDebug}))
   ctx := validator.WithTraceSlog(context.Background(), logger)
 
   v, err := validator.Compile(ctx, s)

--- a/docs/03-references.md
+++ b/docs/03-references.md
@@ -6,19 +6,49 @@ JSON Schema lets you reuse and cross-link sub-schemas with `$ref` and `$dynamicR
 
 Define a schema once under `$defs` and reference it with `$ref`:
 
+<!-- INCLUDE(examples/doc_refdefs_test.go) -->
 ```go
-nameDef := schema.NonEmptyString().MustBuild()
+package examples_test
 
-s := schema.NewBuilder().
-	Types(schema.ObjectType).
-	Definitions("name", nameDef).
-	Property("firstName", schema.NewBuilder().Reference("#/$defs/name").MustBuild()).
-	Property("lastName", schema.NewBuilder().Reference("#/$defs/name").MustBuild()).
-	Required("firstName", "lastName").
-	MustBuild()
+import (
+  "context"
+  "fmt"
+
+  schema "github.com/lestrrat-go/json-schema"
+  "github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_docRefDefs defines a subschema under $defs once and references it from
+// two properties with $ref. References within a document resolve automatically at
+// Compile time — no resolver setup needed.
+func Example_docRefDefs() {
+  nameDef := schema.NonEmptyString().MustBuild()
+  s := schema.NewBuilder().
+    Types(schema.ObjectType).
+    Definitions("name", nameDef).
+    Property("firstName", schema.NewBuilder().Reference("#/$defs/name").MustBuild()).
+    Property("lastName", schema.NewBuilder().Reference("#/$defs/name").MustBuild()).
+    Required("firstName", "lastName").
+    MustBuild()
+
+  ctx := context.Background()
+  v, _ := validator.Compile(ctx, s)
+  check := func(data map[string]any) bool {
+    _, err := v.Validate(ctx, data)
+    return err == nil
+  }
+
+  fmt.Println("both names:  ", check(map[string]any{"firstName": "Ada", "lastName": "Lovelace"}))
+  fmt.Println("empty first: ", check(map[string]any{"firstName": "", "lastName": "Lovelace"}))
+  // Output:
+  // both names:   true
+  // empty first:  false
+}
 ```
+source: [examples/doc_refdefs_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/doc_refdefs_test.go)
+<!-- END INCLUDE -->
 
-`Definitions(name, schema)` adds an entry under `$defs`; `Reference("#/$defs/name")` is a JSON-Pointer `$ref` to it. Both `firstName` and `lastName` now validate against the same `name` definition. The equivalent JSON is:
+`Definitions(name, schema)` adds an entry under `$defs`; `Reference("#/$defs/name")` is a JSON-Pointer `$ref` to it. Both `firstName` and `lastName` validate against the same `name` definition. The equivalent JSON is:
 
 ```json
 {
@@ -36,48 +66,68 @@ References within a document resolve automatically when you `Compile` — no ext
 
 ## External references and the Resolver
 
-When a `$ref` points at *another document* (an absolute URI, not a `#`-fragment of the current schema), the validator needs to find that document. That is the job of `schema.Resolver`. Create one, register the documents it should know about, and put it on the context:
-
-```go
-import "context"
-
-r := schema.NewResolver()
-// ... register documents (below) ...
-
-ctx := schema.WithResolver(context.Background(), r)
-v, err := validator.Compile(ctx, mainSchema)
-// validate with the SAME ctx
-_, err = v.Validate(ctx, data)
-```
+When a `$ref` points at *another document* (an absolute URI, not a `#`-fragment of the current schema), the validator needs to find that document. That is the job of `schema.Resolver`: create one with `schema.NewResolver()`, register the documents it should know about, put it on the context with `schema.WithResolver`, and use that **same** context for both `Compile` and `Validate`.
 
 ### Preloading a tree of files: `RegisterFS`
 
 `RegisterFS(baseURI, fsys)` walks any `fs.FS` and registers every `.json` file under `baseURI` joined with its path. This works with `embed.FS`, `os.DirFS`, or an in-memory `fstest.MapFS`:
 
+<!-- INCLUDE(examples/doc_registerfs_test.go) -->
 ```go
-fsys := fstest.MapFS{
-	"address.json": &fstest.MapFile{Data: []byte(
-		`{"type":"object","properties":{"city":{"type":"string","minLength":1}},"required":["city"]}`,
-	)},
+package examples_test
+
+import (
+  "context"
+  "fmt"
+  "testing/fstest"
+
+  schema "github.com/lestrrat-go/json-schema"
+  "github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_docRegisterFS preloads schema documents from a filesystem with
+// Resolver.RegisterFS, so a $ref to an external URI resolves offline. Each ".json"
+// file is registered under the base URI joined with its path. The fs.FS here is an
+// in-memory fstest.MapFS, but an embed.FS or os.DirFS works the same way.
+func Example_docRegisterFS() {
+  fsys := fstest.MapFS{
+    "address.json": &fstest.MapFile{Data: []byte(
+      `{"type":"object","properties":{"city":{"type":"string","minLength":1}},"required":["city"]}`,
+    )},
+  }
+
+  main := schema.NewBuilder().
+    Types(schema.ObjectType).
+    Property("home", schema.NewBuilder().Reference("https://example.com/schemas/address.json").MustBuild()).
+    Required("home").
+    MustBuild()
+
+  r := schema.NewResolver()
+  if err := r.RegisterFS("https://example.com/schemas/", fsys); err != nil {
+    fmt.Println("register failed:", err)
+    return
+  }
+
+  ctx := schema.WithResolver(context.Background(), r)
+  v, err := validator.Compile(ctx, main)
+  if err != nil {
+    fmt.Println("compile failed:", err)
+    return
+  }
+
+  _, err = v.Validate(ctx, map[string]any{"home": map[string]any{"city": "Kyoto"}})
+  fmt.Println("with city:   ", err == nil)
+  _, err = v.Validate(ctx, map[string]any{"home": map[string]any{}})
+  fmt.Println("without city:", err == nil)
+  // Output:
+  // with city:    true
+  // without city: false
 }
-
-main := schema.NewBuilder().
-	Types(schema.ObjectType).
-	Property("home", schema.NewBuilder().Reference("https://example.com/schemas/address.json").MustBuild()).
-	Required("home").
-	MustBuild()
-
-r := schema.NewResolver()
-if err := r.RegisterFS("https://example.com/schemas/", fsys); err != nil {
-	panic(err)
-}
-
-ctx := schema.WithResolver(context.Background(), r)
-v, _ := validator.Compile(ctx, main)
-_, err := v.Validate(ctx, map[string]any{"home": map[string]any{"city": "Kyoto"}})
 ```
+source: [examples/doc_registerfs_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/doc_registerfs_test.go)
+<!-- END INCLUDE -->
 
-Now a `$ref` to `https://example.com/schemas/address.json` resolves offline against the registered file.
+The `$ref` to `https://example.com/schemas/address.json` resolves offline against the registered file.
 
 ### Registering a single document: `RegisterDocument` / `RegisterRoot`
 

--- a/docs/04-vocabularies-and-meta-schema.md
+++ b/docs/04-vocabularies-and-meta-schema.md
@@ -8,16 +8,50 @@ The default set (`vocabulary.DefaultSet()`) matches the spec default — notably
 
 ## Making `format` assert
 
-By default, `"format": "email"` (and `uuid`, `date-time`, `uri`, …) is informational and will **not** reject malformed values. This is the JSON Schema default, and it surprises people. To enforce formats, enable every standard vocabulary — including format-assertion — on the context you compile and validate with:
+By default, `"format": "email"` (and `uuid`, `date-time`, `uri`, …) is informational and will **not** reject malformed values. This is the JSON Schema default, and it surprises people. To enforce formats, enable every standard vocabulary — including format-assertion — with `vocabulary.WithSet(ctx, vocabulary.AllEnabled())` on the context you compile *and* validate with:
 
+<!-- INCLUDE(examples/doc_format_test.go) -->
 ```go
-import "github.com/lestrrat-go/json-schema/vocabulary"
+package examples_test
 
-ctx := vocabulary.WithSet(context.Background(), vocabulary.AllEnabled())
+import (
+  "context"
+  "fmt"
 
-v, err := validator.Compile(ctx, s)   // same ctx
-_, err = v.Validate(ctx, data)        // same ctx
+  schema "github.com/lestrrat-go/json-schema"
+  "github.com/lestrrat-go/json-schema/validator"
+  "github.com/lestrrat-go/json-schema/vocabulary"
+)
+
+// Example_docFormatAssertion shows that "format" is an annotation by default (it
+// does not reject bad values) and only asserts when the format-assertion
+// vocabulary is enabled via vocabulary.AllEnabled.
+func Example_docFormatAssertion() {
+  s := schema.NewBuilder().
+    Types(schema.ObjectType).
+    Property("email", schema.Email().MustBuild()).
+    MustBuild()
+
+  data := map[string]any{"email": "not-an-email"}
+
+  // Default vocabularies: format is annotation-only, so this passes.
+  def := context.Background()
+  v, _ := validator.Compile(def, s)
+  _, err := v.Validate(def, data)
+  fmt.Println("default set: valid:", err == nil)
+
+  // All vocabularies enabled: format-assertion is on, so this fails.
+  strict := vocabulary.WithSet(context.Background(), vocabulary.AllEnabled())
+  vs, _ := validator.Compile(strict, s)
+  _, err = vs.Validate(strict, data)
+  fmt.Println("all enabled: valid:", err == nil)
+  // Output:
+  // default set: valid: true
+  // all enabled: valid: false
+}
 ```
+source: [examples/doc_format_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/doc_format_test.go)
+<!-- END INCLUDE -->
 
 With `vocabulary.AllEnabled()`, a `schema.Email()` property rejects `"not-an-email"`; with the default set, it does not.
 
@@ -36,27 +70,36 @@ Use the same configured context for `Compile` and `Validate`.
 
 The `meta` package answers a different question: "is this JSON a valid JSON Schema 2020-12 document?" It ships a pre-compiled meta-schema validator, so you do not pay compilation cost.
 
+<!-- INCLUDE(examples/doc_meta_test.go) -->
 ```go
-import "github.com/lestrrat-go/json-schema/meta"
+package examples_test
 
-// Convenience wrapper:
-err := meta.Validate(ctx, map[string]any{
-	"type":      "string",
-	"minLength": 1,
-})
-// err == nil → it's a valid schema
+import (
+  "context"
+  "fmt"
 
-err = meta.Validate(ctx, "not a schema") // err != nil
+  "github.com/lestrrat-go/json-schema/meta"
+)
+
+// Example_docMeta validates that a document is itself a valid JSON Schema 2020-12
+// document, using the pre-compiled meta-schema validator in the meta package.
+func Example_docMeta() {
+  ctx := context.Background()
+
+  validSchema := map[string]any{"type": "string", "minLength": 1}
+  fmt.Println("valid schema:  ", meta.Validate(ctx, validSchema) == nil)
+
+  notASchema := "not a schema"
+  fmt.Println("invalid schema:", meta.Validate(ctx, notASchema) == nil)
+  // Output:
+  // valid schema:   true
+  // invalid schema: false
+}
 ```
+source: [examples/doc_meta_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/doc_meta_test.go)
+<!-- END INCLUDE -->
 
-Or hold the validator directly to reuse it:
-
-```go
-v := meta.Validator() // a validator.Interface
-_, err := v.Validate(ctx, schemaDocument)
-```
-
-This is useful for linting user-supplied schemas before you try to compile them. (The CLI's [`lint`](./06-command-line-tool.md) command is the command-line counterpart.)
+`meta.Validate(ctx, doc)` is a convenience wrapper; `meta.Validator()` returns the underlying reusable `validator.Interface` if you want to hold it directly. This is useful for linting user-supplied schemas before you try to compile them. (The CLI's [`lint`](./06-command-line-tool.md) command is the command-line counterpart.)
 
 ## Next
 

--- a/docs/05-code-generation.md
+++ b/docs/05-code-generation.md
@@ -51,26 +51,52 @@ UserValidator := validator.Object().
 
 `validator.NewCodeGenerator()` returns a `CodeGenerator`; its `Generate` method writes builder source for any compiled validator into an `io.Writer`:
 
+<!-- INCLUDE(examples/doc_codegen_test.go) -->
 ```go
+package examples_test
+
 import (
-	"bytes"
-	"github.com/lestrrat-go/json-schema/validator"
+  "bytes"
+  "context"
+  "fmt"
+
+  schema "github.com/lestrrat-go/json-schema"
+  "github.com/lestrrat-go/json-schema/validator"
 )
 
-v, err := validator.Compile(ctx, s)
-if err != nil {
-	return err
-}
+// Example_docCodegen compiles a schema and emits Go source that reconstructs the
+// validator directly, so production code can skip compilation. This is the
+// programmatic form of the `json-schema gen-validator` CLI command.
+func Example_docCodegen() {
+  s := schema.NewBuilder().
+    Types(schema.StringType).
+    MinLength(1).
+    MustBuild()
 
-var buf bytes.Buffer
-if err := validator.NewCodeGenerator().Generate(&buf, v); err != nil {
-	return err
+  v, err := validator.Compile(context.Background(), s)
+  if err != nil {
+    fmt.Println("compile failed:", err)
+    return
+  }
+
+  var buf bytes.Buffer
+  if err := validator.NewCodeGenerator().Generate(&buf, v); err != nil {
+    fmt.Println("generate failed:", err)
+    return
+  }
+  // Generate emits the raw builder calls (one per line). The gen-validator CLI
+  // additionally assigns them to a variable and runs the result through gofmt.
+  fmt.Print(buf.String())
+  // Output:
+  // validator.String().
+  // MinLength(1).
+  // MustBuild()
 }
-// buf now holds `validator.Object()....MustBuild()` source.
-// Prepend a variable name and run it through go/format before writing to a file.
 ```
+source: [examples/doc_codegen_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/doc_codegen_test.go)
+<!-- END INCLUDE -->
 
-This is exactly what `gen-validator` does internally: compile, `Generate` into a buffer, prepend `name :=`, then `go/format`.
+This is exactly what `gen-validator` does internally: compile, `Generate` into a buffer, prepend `name :=`, then run it through `go/format` for the indented layout shown above.
 
 ## The generated validator builders
 

--- a/examples/doc_builder_test.go
+++ b/examples/doc_builder_test.go
@@ -1,0 +1,50 @@
+package examples_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	schema "github.com/lestrrat-go/json-schema"
+)
+
+// Example_docBuilder builds an object schema with the fluent builder and marshals
+// it to JSON. Object keys are emitted in a stable, sorted order, so the result is
+// deterministic and round-trips cleanly.
+func Example_docBuilder() {
+	s := schema.NewBuilder().
+		Schema(schema.Version).
+		ID("https://example.com/user").
+		Types(schema.ObjectType).
+		Property("name", schema.NewBuilder().Types(schema.StringType).MinLength(1).MustBuild()).
+		Property("age", schema.NewBuilder().Types(schema.IntegerType).Minimum(0).MustBuild()).
+		Required("name").
+		AdditionalProperties(schema.FalseSchema()).
+		MustBuild()
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(s); err != nil {
+		fmt.Println("encode failed:", err)
+	}
+	// Output:
+	// {
+	//   "$id": "https://example.com/user",
+	//   "$schema": "https://json-schema.org/draft/2020-12/schema",
+	//   "additionalProperties": false,
+	//   "properties": {
+	//     "age": {
+	//       "minimum": 0,
+	//       "type": "integer"
+	//     },
+	//     "name": {
+	//       "minLength": 1,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "required": [
+	//     "name"
+	//   ],
+	//   "type": "object"
+	// }
+}

--- a/examples/doc_codegen_test.go
+++ b/examples/doc_codegen_test.go
@@ -1,0 +1,39 @@
+package examples_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_docCodegen compiles a schema and emits Go source that reconstructs the
+// validator directly, so production code can skip compilation. This is the
+// programmatic form of the `json-schema gen-validator` CLI command.
+func Example_docCodegen() {
+	s := schema.NewBuilder().
+		Types(schema.StringType).
+		MinLength(1).
+		MustBuild()
+
+	v, err := validator.Compile(context.Background(), s)
+	if err != nil {
+		fmt.Println("compile failed:", err)
+		return
+	}
+
+	var buf bytes.Buffer
+	if err := validator.NewCodeGenerator().Generate(&buf, v); err != nil {
+		fmt.Println("generate failed:", err)
+		return
+	}
+	// Generate emits the raw builder calls (one per line). The gen-validator CLI
+	// additionally assigns them to a variable and runs the result through gofmt.
+	fmt.Print(buf.String())
+	// Output:
+	// validator.String().
+	// MinLength(1).
+	// MustBuild()
+}

--- a/examples/doc_convenience_test.go
+++ b/examples/doc_convenience_test.go
@@ -1,0 +1,37 @@
+package examples_test
+
+import (
+	"context"
+	"fmt"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_docConvenience composes several one-line convenience constructors —
+// PositiveInteger, Optional, NonEmptyString and Enum — into one object schema.
+// Optional(s) accepts either s or null.
+func Example_docConvenience() {
+	s := schema.NewBuilder().
+		Types(schema.ObjectType).
+		Property("id", schema.PositiveInteger().MustBuild()).
+		Property("nickname", schema.Optional(schema.NonEmptyString().MustBuild()).MustBuild()).
+		Property("role", schema.Enum("admin", "user").MustBuild()).
+		Required("id", "role").
+		MustBuild()
+
+	ctx := context.Background()
+	v, _ := validator.Compile(ctx, s)
+	check := func(data map[string]any) bool {
+		_, err := v.Validate(ctx, data)
+		return err == nil
+	}
+
+	fmt.Println("admin:        ", check(map[string]any{"id": 1, "role": "admin"}))
+	fmt.Println("null nickname:", check(map[string]any{"id": 1, "role": "user", "nickname": nil}))
+	fmt.Println("bad role:     ", check(map[string]any{"id": 1, "role": "root"}))
+	// Output:
+	// admin:         true
+	// null nickname: true
+	// bad role:      false
+}

--- a/examples/doc_format_test.go
+++ b/examples/doc_format_test.go
@@ -1,0 +1,37 @@
+package examples_test
+
+import (
+	"context"
+	"fmt"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+	"github.com/lestrrat-go/json-schema/vocabulary"
+)
+
+// Example_docFormatAssertion shows that "format" is an annotation by default (it
+// does not reject bad values) and only asserts when the format-assertion
+// vocabulary is enabled via vocabulary.AllEnabled.
+func Example_docFormatAssertion() {
+	s := schema.NewBuilder().
+		Types(schema.ObjectType).
+		Property("email", schema.Email().MustBuild()).
+		MustBuild()
+
+	data := map[string]any{"email": "not-an-email"}
+
+	// Default vocabularies: format is annotation-only, so this passes.
+	def := context.Background()
+	v, _ := validator.Compile(def, s)
+	_, err := v.Validate(def, data)
+	fmt.Println("default set: valid:", err == nil)
+
+	// All vocabularies enabled: format-assertion is on, so this fails.
+	strict := vocabulary.WithSet(context.Background(), vocabulary.AllEnabled())
+	vs, _ := validator.Compile(strict, s)
+	_, err = vs.Validate(strict, data)
+	fmt.Println("all enabled: valid:", err == nil)
+	// Output:
+	// default set: valid: true
+	// all enabled: valid: false
+}

--- a/examples/doc_loadjson_test.go
+++ b/examples/doc_loadjson_test.go
@@ -1,0 +1,42 @@
+package examples_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_docLoadJSON loads a schema authored as JSON. *schema.Schema implements
+// json.Unmarshaler, so json.Unmarshal is all it takes; the result compiles and
+// validates exactly like a schema built with the fluent builder.
+func Example_docLoadJSON() {
+	const doc = `{
+		"type": "object",
+		"properties": { "city": { "type": "string", "minLength": 1 } },
+		"required": ["city"]
+	}`
+
+	var s schema.Schema
+	if err := json.Unmarshal([]byte(doc), &s); err != nil {
+		fmt.Println("parse failed:", err)
+		return
+	}
+
+	ctx := context.Background()
+	v, err := validator.Compile(ctx, &s)
+	if err != nil {
+		fmt.Println("compile failed:", err)
+		return
+	}
+
+	_, err = v.Validate(ctx, map[string]any{"city": "Kyoto"})
+	fmt.Println("with city:   ", err == nil)
+	_, err = v.Validate(ctx, map[string]any{})
+	fmt.Println("without city:", err == nil)
+	// Output:
+	// with city:    true
+	// without city: false
+}

--- a/examples/doc_meta_test.go
+++ b/examples/doc_meta_test.go
@@ -1,0 +1,23 @@
+package examples_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lestrrat-go/json-schema/meta"
+)
+
+// Example_docMeta validates that a document is itself a valid JSON Schema 2020-12
+// document, using the pre-compiled meta-schema validator in the meta package.
+func Example_docMeta() {
+	ctx := context.Background()
+
+	validSchema := map[string]any{"type": "string", "minLength": 1}
+	fmt.Println("valid schema:  ", meta.Validate(ctx, validSchema) == nil)
+
+	notASchema := "not a schema"
+	fmt.Println("invalid schema:", meta.Validate(ctx, notASchema) == nil)
+	// Output:
+	// valid schema:   true
+	// invalid schema: false
+}

--- a/examples/doc_quickstart_test.go
+++ b/examples/doc_quickstart_test.go
@@ -1,0 +1,47 @@
+package examples_test
+
+import (
+	"context"
+	"fmt"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_docQuickStart shows the three core steps: build a schema, compile it
+// into a validator, and validate data. A compiled validator is reusable across
+// many Validate calls and safe for concurrent use.
+func Example_docQuickStart() {
+	ctx := context.Background()
+
+	// 1. Build a schema.
+	s := schema.NewBuilder().
+		Schema(schema.Version).
+		Types(schema.ObjectType).
+		Property("name", schema.NonEmptyString().MustBuild()).
+		Property("email", schema.Email().MustBuild()).
+		Property("age", schema.PositiveInteger().MustBuild()).
+		Required("name", "email").
+		MustBuild()
+
+	// 2. Compile it into a validator.
+	v, err := validator.Compile(ctx, s)
+	if err != nil {
+		fmt.Println("compile failed:", err)
+		return
+	}
+
+	// 3. Validate data.
+	_, err = v.Validate(ctx, map[string]any{
+		"name":  "Ada Lovelace",
+		"email": "ada@example.com",
+		"age":   36,
+	})
+	fmt.Println("valid record:", err == nil)
+
+	_, err = v.Validate(ctx, map[string]any{"name": "", "email": "x"})
+	fmt.Println("empty name:  ", err == nil)
+	// Output:
+	// valid record: true
+	// empty name:   false
+}

--- a/examples/doc_refdefs_test.go
+++ b/examples/doc_refdefs_test.go
@@ -1,0 +1,36 @@
+package examples_test
+
+import (
+	"context"
+	"fmt"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_docRefDefs defines a subschema under $defs once and references it from
+// two properties with $ref. References within a document resolve automatically at
+// Compile time — no resolver setup needed.
+func Example_docRefDefs() {
+	nameDef := schema.NonEmptyString().MustBuild()
+	s := schema.NewBuilder().
+		Types(schema.ObjectType).
+		Definitions("name", nameDef).
+		Property("firstName", schema.NewBuilder().Reference("#/$defs/name").MustBuild()).
+		Property("lastName", schema.NewBuilder().Reference("#/$defs/name").MustBuild()).
+		Required("firstName", "lastName").
+		MustBuild()
+
+	ctx := context.Background()
+	v, _ := validator.Compile(ctx, s)
+	check := func(data map[string]any) bool {
+		_, err := v.Validate(ctx, data)
+		return err == nil
+	}
+
+	fmt.Println("both names:  ", check(map[string]any{"firstName": "Ada", "lastName": "Lovelace"}))
+	fmt.Println("empty first: ", check(map[string]any{"firstName": "", "lastName": "Lovelace"}))
+	// Output:
+	// both names:   true
+	// empty first:  false
+}

--- a/examples/doc_registerfs_test.go
+++ b/examples/doc_registerfs_test.go
@@ -1,0 +1,49 @@
+package examples_test
+
+import (
+	"context"
+	"fmt"
+	"testing/fstest"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_docRegisterFS preloads schema documents from a filesystem with
+// Resolver.RegisterFS, so a $ref to an external URI resolves offline. Each ".json"
+// file is registered under the base URI joined with its path. The fs.FS here is an
+// in-memory fstest.MapFS, but an embed.FS or os.DirFS works the same way.
+func Example_docRegisterFS() {
+	fsys := fstest.MapFS{
+		"address.json": &fstest.MapFile{Data: []byte(
+			`{"type":"object","properties":{"city":{"type":"string","minLength":1}},"required":["city"]}`,
+		)},
+	}
+
+	main := schema.NewBuilder().
+		Types(schema.ObjectType).
+		Property("home", schema.NewBuilder().Reference("https://example.com/schemas/address.json").MustBuild()).
+		Required("home").
+		MustBuild()
+
+	r := schema.NewResolver()
+	if err := r.RegisterFS("https://example.com/schemas/", fsys); err != nil {
+		fmt.Println("register failed:", err)
+		return
+	}
+
+	ctx := schema.WithResolver(context.Background(), r)
+	v, err := validator.Compile(ctx, main)
+	if err != nil {
+		fmt.Println("compile failed:", err)
+		return
+	}
+
+	_, err = v.Validate(ctx, map[string]any{"home": map[string]any{"city": "Kyoto"}})
+	fmt.Println("with city:   ", err == nil)
+	_, err = v.Validate(ctx, map[string]any{"home": map[string]any{}})
+	fmt.Println("without city:", err == nil)
+	// Output:
+	// with city:    true
+	// without city: false
+}

--- a/examples/doc_tracing_test.go
+++ b/examples/doc_tracing_test.go
@@ -1,9 +1,9 @@
 package examples_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 
 	schema "github.com/lestrrat-go/json-schema"
@@ -13,7 +13,8 @@ import (
 // Example_docTracing attaches a structured trace logger with WithTraceSlog. The
 // logger records the validation walk keyword by keyword, which is the fastest way
 // to see why an input was rejected. In real use point the handler at os.Stderr;
-// here it is discarded so the example output stays deterministic.
+// here it writes to a buffer that is never printed, so the example output stays
+// deterministic.
 func Example_docTracing() {
 	s := schema.NewBuilder().
 		Types(schema.ObjectType).
@@ -21,7 +22,8 @@ func Example_docTracing() {
 		Required("id").
 		MustBuild()
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	var traceOut bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&traceOut, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	ctx := validator.WithTraceSlog(context.Background(), logger)
 
 	v, err := validator.Compile(ctx, s)

--- a/examples/doc_tracing_test.go
+++ b/examples/doc_tracing_test.go
@@ -1,0 +1,37 @@
+package examples_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_docTracing attaches a structured trace logger with WithTraceSlog. The
+// logger records the validation walk keyword by keyword, which is the fastest way
+// to see why an input was rejected. In real use point the handler at os.Stderr;
+// here it is discarded so the example output stays deterministic.
+func Example_docTracing() {
+	s := schema.NewBuilder().
+		Types(schema.ObjectType).
+		Property("id", schema.PositiveInteger().MustBuild()).
+		Required("id").
+		MustBuild()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx := validator.WithTraceSlog(context.Background(), logger)
+
+	v, err := validator.Compile(ctx, s)
+	if err != nil {
+		fmt.Println("compile failed:", err)
+		return
+	}
+
+	_, err = v.Validate(ctx, map[string]any{"id": 1})
+	fmt.Println("valid:", err == nil)
+	// Output:
+	// valid: true
+}

--- a/examples/doc_validate_test.go
+++ b/examples/doc_validate_test.go
@@ -1,0 +1,38 @@
+package examples_test
+
+import (
+	"context"
+	"fmt"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_docValidate compiles a schema once and reuses the validator for several
+// inputs. Validate returns a non-nil error when the data is invalid.
+func Example_docValidate() {
+	s := schema.NewBuilder().
+		Types(schema.ObjectType).
+		Property("id", schema.PositiveInteger().MustBuild()).
+		Property("role", schema.Enum("admin", "user").MustBuild()).
+		Required("id", "role").
+		MustBuild()
+
+	ctx := context.Background()
+	v, err := validator.Compile(ctx, s)
+	if err != nil {
+		fmt.Println("compile failed:", err)
+		return
+	}
+
+	for _, data := range []map[string]any{
+		{"id": 1, "role": "admin"}, // valid
+		{"id": 1, "role": "root"},  // role not in enum
+	} {
+		_, err := v.Validate(ctx, data)
+		fmt.Printf("valid=%t\n", err == nil)
+	}
+	// Output:
+	// valid=true
+	// valid=false
+}


### PR DESCRIPTION
- Replace hand-written `docs/` code blocks with `<!-- INCLUDE -->` markers backed by real, executable example tests (the README/autodoc mechanism)
- Add 11 self-contained example tests under `examples/doc_*_test.go` covering quickstart, builder, convenience, load-from-JSON, validate, tracing, $ref/$defs, RegisterFS, format-assertion, meta-schema, and code generation
- Drop non-runnable illustrative fragments to prose; all docs Go code is now compiled and run by `go test`
- Pre-filled INCLUDE blocks match `tools/autodoc.pl` output exactly (verified against README), so no autodoc cleanup PR on merge

Merge #35 (autodoc CLAUDE.md exclusion) first: on merge, autodoc reprocesses `docs/*.md`; with #35 in place it leaves the `CLAUDE.md` symlink alone.
