### PR TITLE
fix: migrate doc examples off context bag

### DIFF
--- a/examples/doc_format_test.go
+++ b/examples/doc_format_test.go
@@ -27,8 +27,8 @@ func Example_docFormatAssertion() {
 	fmt.Println("default set: valid:", err == nil)
 
 	// All vocabularies enabled: format-assertion is on, so this fails.
-	strict := vocabulary.WithSet(context.Background(), vocabulary.AllEnabled())
-	vs, _ := validator.Compile(strict, s)
+	strict := context.Background()
+	vs, _ := validator.Compile(strict, s, validator.WithVocabularySet(vocabulary.AllEnabled()))
 	_, err = vs.Validate(strict, data)
 	fmt.Println("all enabled: valid:", err == nil)
 	// Output:

--- a/examples/doc_registerfs_test.go
+++ b/examples/doc_registerfs_test.go
@@ -32,8 +32,8 @@ func Example_docRegisterFS() {
 		return
 	}
 
-	ctx := schema.WithResolver(context.Background(), r)
-	v, err := validator.Compile(ctx, main)
+	ctx := context.Background()
+	v, err := validator.Compile(ctx, main, validator.WithResolver(r))
 	if err != nil {
 		fmt.Println("compile failed:", err)
 		return


### PR DESCRIPTION
- `doc_format_test.go` / `doc_registerfs_test.go` still called the context-bag helpers `vocabulary.WithSet` / `schema.WithResolver` removed in #38, breaking the lint (typecheck) job on main
- migrate both to the `validator.WithVocabularySet` / `validator.WithResolver` compile options
