### PR TITLE
ci: run full test suite on main PRs and pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 name: CI
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
-      - v*
-      - develop/*
+      - main
 
 jobs:
   generate:


### PR DESCRIPTION
- `ci.yml` (the `go test ./...` job that compiles & runs `examples/`) only triggered on PRs to `v*`/`develop/*`, with no `push` trigger — so it never ran for this `main`-based repo
- this let #38 break `examples/` undetected at PR time; only the post-merge `lint` push job caught it (→ #39)
- trigger `ci.yml` on `push` and `pull_request` to `main`
