### PR TITLE
make resolver network/filesystem access opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Go module implementing JSON Schema validation following the [JSON Schema 2020-12
   * All validation keywords (type, properties, items, etc.)
   * Schema composition (allOf, anyOf, oneOf)
   * Conditional schemas (if/then/else)
-  * Reference resolution ($ref, $anchor, $dynamicRef)
+  * Reference resolution ($ref, $anchor, $dynamicRef) — in-memory by default; network/filesystem access is opt-in
   * Format validation (email, uri, date-time, etc.)
   * Content validation (base64, json-pointer, etc.)
 * Clean separation between schema construction and validation
@@ -19,6 +19,28 @@ Go module implementing JSON Schema validation following the [JSON Schema 2020-12
   * No schema files to embed and no runtime schema compilation in production
 * Command-line tool for schema validation and code generation
 * Comprehensive test coverage including JSON Schema Test Suite compliance
+
+> [!IMPORTANT]
+> **Reference resolution is in-memory by default — external access is opt-in.**
+> A `$ref`/`$dynamicRef` to another document resolves **only** from schemas you
+> have registered in memory. The resolver does **not** reach out to the network
+> or read the local filesystem unless you explicitly enable it. This prevents
+> surprise outbound fetches (SSRF) and unexpected disk reads.
+>
+> **If you relied on the old behavior where external `$ref`s were fetched
+> automatically, you must now opt in:**
+>
+> ```go
+> // Default: in-memory only. Preload externals with RegisterFS / RegisterDocument.
+> r := schema.NewResolver()
+>
+> // Opt in to live access when you want it:
+> r = schema.NewResolver(schema.WithResolver(schema.HTTPResolver()))    // HTTP/HTTPS
+> r = schema.NewResolver(schema.WithResolver(schema.DirResolver(".")))  // local files under "."
+> r = schema.NewResolver(schema.WithResolver(schema.FSResolver(fsys)))  // any io/fs (embed.FS, …)
+> ```
+>
+> See [References](./docs/03-references.md) for details.
 
 # SYNOPSIS
 

--- a/agents/docs/packages.md
+++ b/agents/docs/packages.md
@@ -18,8 +18,8 @@ JSON Schema data type + fluent builder + reference resolver + context helpers. P
 - Convenience constructors → `*Builder` (patterns.go): `Email()`, `URL()`, `UUID()`, `Date()`, `DateTime()`, `NonEmptyString()`, `AlphanumericString()`, `PositiveNumber()`, `PositiveInteger()`, `Enum(...any)`, `OneOf(...*Schema)`, `AnyOf(...*Schema)`, `AllOf(...*Schema)`, `Optional(*Schema)` (schema-or-null).
 - Field bitfield: `FieldFlag` constants `XxxField` (one per keyword) + grouped sets `StringConstraintFields`, `NumericConstraintFields`, `ObjectConstraintFields`, `ArrayConstraintFields`, `CompositionFields`, `ConditionalFields`, `ContentFields`, etc. `(*Schema).Has(FieldFlag) bool`, `HasAny(FieldFlag) bool`, plus `HasXxx()` per keyword.
 - URI: **ResolveURI(base, ref string) string** (uri.go, RFC 3986).
-- Resolver: **NewResolver() \*Resolver**; methods `RegisterRoot(*Schema)`, `RegisterDocument(uri string, root *Schema)`, `RegisterFS(baseURI string, fs.FS) error`, `ResourceFor(uri string) *Schema`, `ResolveReference(ctx, dst any, ref string) error` (resolver.go). **FindDynamicAnchor(resource *Schema, name string) *Schema** (registry.go).
-- Context helpers (schema.go): `WithBaseURI`/`BaseURIFromContext`, `WithBaseSchema`/`BaseSchemaFromContext`, `WithResolver`/`ResolverFromContext`, `WithRootSchema`/`RootSchemaFromContext`, `WithDynamicScope`/`DynamicScopeFromContext`, `WithDynamicAnchorValidator`/`DynamicAnchorValidatorFromContext`.
+- Resolver: **NewResolver(...ResolverOption) \*Resolver** (external access is opt-in; bare resolver is in-memory only); methods `RegisterRoot(*Schema)`, `RegisterDocument(uri string, root *Schema)`, `RegisterFS(baseURI string, fs.FS) error`, `ResourceFor(uri string) *Schema`, `ResolveReference(ctx, dst any, ref string) error` (resolver.go). **FindDynamicAnchor(resource *Schema, name string) *Schema** (registry.go).
+- Resolver options (resolver_options.go): **ResolverOption**, **WithResolver(jsref.Resolver)**, and opt-in resolver factories **HTTPResolver() jsref.Resolver**, **FSResolver(fs.FS) jsref.Resolver**, **DirResolver(dir string) jsref.Resolver**.
 
 ## validator/
 

--- a/agents/docs/references.md
+++ b/agents/docs/references.md
@@ -8,13 +8,14 @@ Covers `$ref`, `$id`, `$anchor`, `$dynamicRef`, `$dynamicAnchor`, and the `schem
 
 - `uri.go` — `ResolveURI` (RFC 3986 base+ref join).
 - `registry.go` — `resourceIndex` (absolute URI → schema, plus anchors), `FindDynamicAnchor`, child-schema enumeration.
-- `resolver.go` — `Resolver`: a `registryResolver` stacked ahead of HTTP / FS / object resolvers (via `lestrrat-go/jsref/v2`). `RegisterRoot`, `RegisterDocument`, `RegisterFS`, `ResourceFor`, `ResolveReference`.
+- `resolver.go` — `Resolver`: a `registryResolver` stacked ahead of any caller-supplied resolvers, then a final object resolver (via `lestrrat-go/jsref/v2`). `NewResolver(...ResolverOption)`, `RegisterRoot`, `RegisterDocument`, `RegisterFS`, `ResourceFor`, `ResolveReference`.
+- `resolver_options.go` — `ResolverOption`, `WithResolver`, and the opt-in resolver factories `HTTPResolver`, `FSResolver(fs.FS)`, `DirResolver(dir)` plus the `fs.FS`-backed `fsResolver`.
 - `validator/compiler.go` — the eager `$ref` resolution block.
 - `validator/reference.go` — `ReferenceValidator`, `DynamicReferenceValidator`, `plainAnchorFragment`.
 
 ## In-document `$id` registry
 
-A `resourceIndex` maps absolute URIs → schemas and is consulted by the `registryResolver` before any network/FS resolver. Built at the root `Compile` via `Resolver.RegisterRoot`.
+A `resourceIndex` maps absolute URIs → schemas and is consulted by the `registryResolver` before any opt-in network/FS resolver. Built at the root `Compile` via `Resolver.RegisterRoot`.
 
 `RegisterRoot` is **deduped per root** (a `registered` map guarded by `Resolver.mu`). This is required: validate-time recompiles must NOT re-index, or a data race results. Do not remove the dedup.
 
@@ -40,7 +41,8 @@ When a `$ref` enters another resource, `compileSchema` sets the base URI to the 
 
 - `Resolver.RegisterDocument(uri, root)` preloads a document under an explicit *retrieval* URI; it becomes addressable both by that URI and by its own canonical `$id`. The conformance suite loads its `remotes/` tree this way (`loadRemotes`/`newSuiteResolver` in `schema_compliance_test.go`).
 - `Resolver.RegisterFS(baseURI, fsys)` walks an `fs.FS` and registers every `.json` file under `baseURI` joined with its path. Works with `embed.FS`, `os.DirFS`, `fstest.MapFS`.
-- HTTP fetching is available via the stacked resolver but offline preloading (RegisterDocument/RegisterFS) is preferred for tests and reproducible builds.
+- **External access is opt-in.** A bare `NewResolver()` resolves only from memory (registry + preloaded docs); an external `$ref` that is not preloaded fails rather than being fetched. To allow it, pass a resolver explicitly: `NewResolver(WithResolver(HTTPResolver()))` for HTTP/HTTPS, `NewResolver(WithResolver(DirResolver(".")))` or `WithResolver(FSResolver(fsys))` for files. The FS resolvers are backed by `io/fs` and accept JSON or YAML documents.
+- Offline preloading (RegisterDocument/RegisterFS) remains preferred for tests and reproducible builds.
 
 ## Pre-compiled meta validator + `$dynamicRef` (a real footgun, already fixed)
 

--- a/docs/02-validating.md
+++ b/docs/02-validating.md
@@ -65,15 +65,14 @@ func Example_docValidate() {
 source: [examples/doc_validate_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/doc_validate_test.go)
 <!-- END INCLUDE -->
 
-## Pass the same context to Compile and Validate
+## Configuring Compile and Validate
 
-Optional behavior is configured on the `context.Context` and read at both compile and validate time:
+Optional behavior is configured two ways:
 
-- A custom [reference resolver](./03-references.md) (`schema.WithResolver`)
-- A different [vocabulary set](./04-vocabularies-and-meta-schema.md) (`vocabulary.WithSet`)
-- A [trace logger](#tracing) (`validator.WithTraceSlog`)
-
-Build the context once and pass it to **both** calls. Compiling with a resolver but validating without it (or vice-versa) can lead to surprising results.
+- **Compile options** passed to `validator.Compile(ctx, schema, opts...)`:
+  - A custom [reference resolver](./03-references.md) — `validator.WithResolver(r)`. Note that external (`network`/`filesystem`) access is **opt-in** on the resolver itself; see [References](./03-references.md).
+  - A different [vocabulary set](./04-vocabularies-and-meta-schema.md) — `validator.WithVocabularySet(vs)`.
+- **A trace logger** carried on the `context.Context` — `validator.WithTraceSlog(ctx, logger)` — and read while validating (see [Tracing](#tracing)).
 
 ## `format` does not assert by default
 

--- a/docs/03-references.md
+++ b/docs/03-references.md
@@ -2,6 +2,9 @@
 
 JSON Schema lets you reuse and cross-link sub-schemas with `$ref` and `$dynamicRef`, anchored by `$id`, `$anchor`, and `$dynamicAnchor`. This library resolves all of them; this guide covers the common cases and how to point the resolver at external documents.
 
+> [!IMPORTANT]
+> **External access is opt-in.** A `schema.Resolver` resolves references **only from memory** by default — it never touches the network or the filesystem unless you explicitly enable it. An external `$ref` you have not preloaded (or whose access you have not opted into) fails to resolve rather than being silently fetched. To allow live access, pass `WithResolver(HTTPResolver())` (HTTP/HTTPS), `WithResolver(DirResolver("."))`, or `WithResolver(FSResolver(fsys))`. See [External references and the Resolver](#external-references-and-the-resolver) below.
+
 ## Reusing a sub-schema with `$ref` and `$defs`
 
 Define a schema once under `$defs` and reference it with `$ref`:
@@ -66,7 +69,17 @@ References within a document resolve automatically when you `Compile` — no ext
 
 ## External references and the Resolver
 
-When a `$ref` points at *another document* (an absolute URI, not a `#`-fragment of the current schema), the validator needs to find that document. That is the job of `schema.Resolver`: create one with `schema.NewResolver()`, register the documents it should know about, put it on the context with `schema.WithResolver`, and use that **same** context for both `Compile` and `Validate`.
+When a `$ref` points at *another document* (an absolute URI, not a `#`-fragment of the current schema), the validator needs to find that document. That is the job of `schema.Resolver`: create one with `schema.NewResolver()`, register the documents it should know about, and pass it to `Compile` with `validator.WithResolver(r)`.
+
+> **External access is opt-in.** A bare `schema.NewResolver()` resolves references **only from memory** — in-document `$id` resources and documents you preload (below). It never reaches the network or the filesystem on its own, so an external `$ref` you have not preloaded fails to resolve instead of being silently fetched. To allow live access, hand the resolver explicit resolvers:
+>
+> ```go
+> r := schema.NewResolver(schema.WithResolver(schema.HTTPResolver()))      // allow HTTP/HTTPS
+> r := schema.NewResolver(schema.WithResolver(schema.DirResolver(".")))   // allow local files under "."
+> r := schema.NewResolver(schema.WithResolver(schema.FSResolver(fsys)))   // allow files from any io/fs
+> ```
+>
+> Preloading (below) is preferred over live access for tests and reproducible builds.
 
 ### Preloading a tree of files: `RegisterFS`
 
@@ -134,7 +147,7 @@ The `$ref` to `https://example.com/schemas/address.json` resolves offline agains
 - `RegisterDocument(uri, root)` preloads one document under an explicit retrieval URI. The document becomes addressable both by that URI **and** by its own canonical `$id`.
 - `RegisterRoot(root)` indexes a schema's own `$id`/anchors (the root `Compile` does this for you automatically).
 
-Preloading documents is preferred over live HTTP fetching for tests and reproducible builds.
+Preloading documents is preferred over live HTTP fetching (which is opt-in; see above) for tests and reproducible builds.
 
 ## `$id`, `$anchor`, `$dynamicAnchor`
 

--- a/docs/03-references.md
+++ b/docs/03-references.md
@@ -81,6 +81,70 @@ When a `$ref` points at *another document* (an absolute URI, not a `#`-fragment 
 >
 > Preloading (below) is preferred over live access for tests and reproducible builds.
 
+### Opting in to live access
+
+`FSResolver(fsys)` (any `io/fs`), `DirResolver(dir)` (the local filesystem), and `HTTPResolver()` (the network) each enable one kind of live resolution when passed to `WithResolver`. A bare resolver does none of them:
+
+<!-- INCLUDE(examples/resolver_optin_example_test.go) -->
+```go
+package examples_test
+
+import (
+  "context"
+  "fmt"
+  "testing/fstest"
+
+  schema "github.com/lestrrat-go/json-schema"
+  "github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_resolverOptIn shows that external reference resolution is opt-in. A
+// bare schema.NewResolver() resolves only from memory; to let a $ref reach the
+// filesystem you must hand it an explicit resolver. Here FSResolver reads from
+// an in-memory fs.FS on demand (use DirResolver(".") for the local filesystem or
+// HTTPResolver() for the network the same way). Contrast with Example_docRegisterFS,
+// which preloads the documents instead.
+func Example_resolverOptIn() {
+  fsys := fstest.MapFS{
+    "address.json": &fstest.MapFile{Data: []byte(
+      `{"type":"object","properties":{"city":{"type":"string","minLength":1}},"required":["city"]}`,
+    )},
+  }
+
+  main := schema.NewBuilder().
+    Types(schema.ObjectType).
+    Property("home", schema.NewBuilder().Reference("address.json").MustBuild()).
+    Required("home").
+    MustBuild()
+
+  ctx := context.Background()
+
+  // Default resolver: no filesystem access, so the external $ref cannot resolve.
+  if _, err := validator.Compile(ctx, main, validator.WithResolver(schema.NewResolver())); err != nil {
+    fmt.Println("default (in-memory only):", err != nil)
+  }
+
+  // Opt in to filesystem access with FSResolver.
+  r := schema.NewResolver(schema.WithResolver(schema.FSResolver(fsys)))
+  v, err := validator.Compile(ctx, main, validator.WithResolver(r))
+  if err != nil {
+    fmt.Println("compile failed:", err)
+    return
+  }
+
+  _, err = v.Validate(ctx, map[string]any{"home": map[string]any{"city": "Kyoto"}})
+  fmt.Println("with city:   ", err == nil)
+  _, err = v.Validate(ctx, map[string]any{"home": map[string]any{}})
+  fmt.Println("without city:", err == nil)
+  // Output:
+  // default (in-memory only): true
+  // with city:    true
+  // without city: false
+}
+```
+source: [examples/resolver_optin_example_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/resolver_optin_example_test.go)
+<!-- END INCLUDE -->
+
 ### Preloading a tree of files: `RegisterFS`
 
 `RegisterFS(baseURI, fsys)` walks any `fs.FS` and registers every `.json` file under `baseURI` joined with its path. This works with `embed.FS`, `os.DirFS`, or an in-memory `fstest.MapFS`:

--- a/docs/99-faq.md
+++ b/docs/99-faq.md
@@ -22,11 +22,16 @@ Use the `meta` package: `meta.Validate(ctx, document)` or `meta.Validator()`. It
 
 ### My `$ref` to an external URL won't resolve.
 
-External references need a resolver that knows about the target document. Create a `schema.Resolver`, register the document(s) with `RegisterFS`/`RegisterDocument`, put it on the context with `schema.WithResolver`, and use that context for both `Compile` and `Validate`. See [References](./03-references.md).
+By design, a resolver **resolves only from memory by default** — it will not fetch over the network or read the filesystem unless you opt in. You have two choices:
 
-### I configured the context but nothing changed.
+- **Preload (recommended):** create a `schema.Resolver`, register the target document(s) with `RegisterFS`/`RegisterDocument`, and pass it to `Compile` with `validator.WithResolver(r)`.
+- **Opt into live access:** `schema.NewResolver(schema.WithResolver(schema.HTTPResolver()))` for HTTP/HTTPS, or `schema.WithResolver(schema.DirResolver("."))` / `schema.WithResolver(schema.FSResolver(fsys))` for files.
 
-Optional behavior (resolver, vocabularies, tracing) is read from the context at **both** compile and validate time. Pass the *same* configured context to `Compile` and to `Validate`. Configuring one but not the other is the most common cause of "it didn't take effect".
+See [References](./03-references.md).
+
+### I configured something but nothing changed.
+
+The resolver and vocabulary set are **`Compile` options** — pass them to `validator.Compile(ctx, schema, validator.WithResolver(r), validator.WithVocabularySet(vs))`, not after the fact. The trace logger is carried on the `context.Context` (`validator.WithTraceSlog`) and read while validating. Configuring the wrong stage is the most common cause of "it didn't take effect". See [Validating Data](./02-validating.md#configuring-compile-and-validate).
 
 ### Why did my recursive schema fail to compile with a circular-reference error?
 

--- a/examples/resolver_optin_example_test.go
+++ b/examples/resolver_optin_example_test.go
@@ -1,0 +1,54 @@
+package examples_test
+
+import (
+	"context"
+	"fmt"
+	"testing/fstest"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_resolverOptIn shows that external reference resolution is opt-in. A
+// bare schema.NewResolver() resolves only from memory; to let a $ref reach the
+// filesystem you must hand it an explicit resolver. Here FSResolver reads from
+// an in-memory fs.FS on demand (use DirResolver(".") for the local filesystem or
+// HTTPResolver() for the network the same way). Contrast with Example_docRegisterFS,
+// which preloads the documents instead.
+func Example_resolverOptIn() {
+	fsys := fstest.MapFS{
+		"address.json": &fstest.MapFile{Data: []byte(
+			`{"type":"object","properties":{"city":{"type":"string","minLength":1}},"required":["city"]}`,
+		)},
+	}
+
+	main := schema.NewBuilder().
+		Types(schema.ObjectType).
+		Property("home", schema.NewBuilder().Reference("address.json").MustBuild()).
+		Required("home").
+		MustBuild()
+
+	ctx := context.Background()
+
+	// Default resolver: no filesystem access, so the external $ref cannot resolve.
+	if _, err := validator.Compile(ctx, main, validator.WithResolver(schema.NewResolver())); err != nil {
+		fmt.Println("default (in-memory only):", err != nil)
+	}
+
+	// Opt in to filesystem access with FSResolver.
+	r := schema.NewResolver(schema.WithResolver(schema.FSResolver(fsys)))
+	v, err := validator.Compile(ctx, main, validator.WithResolver(r))
+	if err != nil {
+		fmt.Println("compile failed:", err)
+		return
+	}
+
+	_, err = v.Validate(ctx, map[string]any{"home": map[string]any{"city": "Kyoto"}})
+	fmt.Println("with city:   ", err == nil)
+	_, err = v.Validate(ctx, map[string]any{"home": map[string]any{}})
+	fmt.Println("without city:", err == nil)
+	// Output:
+	// default (in-memory only): true
+	// with city:    true
+	// without city: false
+}

--- a/go.mod
+++ b/go.mod
@@ -3,19 +3,19 @@ module github.com/lestrrat-go/json-schema
 go 1.24.4
 
 require (
+	github.com/goccy/go-yaml v1.19.2
 	github.com/lestrrat-go/codegen v1.0.4
 	github.com/lestrrat-go/jsref/v2 v2.0.0-20250713032959-1507af0872ba
+	github.com/lestrrat-go/option/v3 v3.0.0-alpha1
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v3 v3.9.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
 	github.com/lestrrat-go/jsptr v0.0.0-20250712081548-ece4951ef7eb // indirect
 	github.com/lestrrat-go/option v1.0.0 // indirect
-	github.com/lestrrat-go/option/v3 v3.0.0-alpha1 // indirect
 	github.com/lestrrat-go/xstrings v0.0.0-20210804220435-4dd8b234342b // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect

--- a/resolver.go
+++ b/resolver.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/lestrrat-go/jsref/v2"
+	"github.com/lestrrat-go/option/v3"
 )
 
 // Resolver provides JSON Schema reference resolution capabilities.
@@ -22,28 +23,37 @@ type Resolver struct {
 	registered map[*Schema]struct{} // roots already indexed, to avoid re-indexing
 }
 
-// NewResolver creates a new schema resolver with in-document, HTTP and
-// filesystem support.
-func NewResolver() *Resolver {
+// NewResolver creates a new schema resolver. By default it resolves references
+// only from memory: in-document $id resources/anchors and documents preloaded
+// via RegisterRoot/RegisterDocument/RegisterFS.
+//
+// Access to system resources is opt-in. To let references reach the network or
+// the filesystem, pass resolvers explicitly with WithResolver — for example
+// WithResolver(HTTPResolver()) for HTTP/HTTPS or WithResolver(DirResolver("."))
+// for local files. Without those, an external $ref that is not preloaded fails
+// to resolve rather than silently fetching it.
+func NewResolver(options ...ResolverOption) *Resolver {
 	resolver := jsref.New()
 
 	index := newResourceIndex()
 
 	// Add the in-document resolver FIRST so references whose base URI names a
-	// known $id resource are resolved from memory before any network/filesystem
-	// access is attempted. It declines unknown URIs, falling through to the
-	// resolvers below.
+	// known $id resource are resolved from memory before any opt-in network/
+	// filesystem access is attempted. It declines unknown URIs, falling through
+	// to the resolvers below.
 	resolver.AddResolver(&registryResolver{idx: index, obj: jsref.NewObjectResolver()})
 
-	// Add HTTP resolver for remote schema references
-	resolver.AddResolver(jsref.NewHTTPResolver())
-
-	// Add filesystem resolver rooted at current directory for local files
-	if fsResolver, err := jsref.NewFSResolver("."); err == nil {
-		resolver.AddResolver(fsResolver)
+	// Add caller-supplied resolvers (HTTP, filesystem, custom) in order. These
+	// sit between the in-document registry and the final JSON-pointer fallback.
+	for _, o := range options {
+		if o.Ident() == (identResolver{}) {
+			resolver.AddResolver(option.MustGet[jsref.Resolver](o))
+		}
 	}
 
-	// Add object resolver for JSON pointer resolution within map data structures
+	// Add object resolver LAST for JSON pointer resolution within map data
+	// structures. Its CanResolve accepts everything, so it must stay last or it
+	// would shadow the resolvers above.
 	resolver.AddResolver(jsref.NewObjectResolver())
 
 	return &Resolver{resolver: resolver, index: index}

--- a/resolver_options.go
+++ b/resolver_options.go
@@ -1,0 +1,137 @@
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/lestrrat-go/jsref/v2"
+	"github.com/lestrrat-go/option/v3"
+)
+
+// ResolverOption configures NewResolver.
+type ResolverOption interface {
+	option.Interface
+	resolverOption()
+}
+
+type resolverOption struct{ option.Interface }
+
+func (resolverOption) resolverOption() {}
+
+type identResolver struct{}
+
+// WithResolver appends an external reference resolver to the resolver stack.
+//
+// By default NewResolver resolves references only from memory (in-document $id
+// resources and preloaded documents). To allow a resolver to reach outside the
+// process — over the network or to the filesystem — supply it explicitly:
+// HTTPResolver for HTTP/HTTPS, FSResolver/DirResolver for files,
+// or any custom jsref.Resolver.
+//
+// WithResolver may be supplied multiple times; the resolvers are consulted in
+// the order given, after the in-document registry and before the final
+// JSON-pointer fallback.
+func WithResolver(r jsref.Resolver) ResolverOption {
+	return resolverOption{option.New(identResolver{}, r)}
+}
+
+// HTTPResolver returns a resolver that fetches remote references over HTTP/HTTPS.
+// Pass it to WithResolver to enable network access:
+//
+//	r := schema.NewResolver(schema.WithResolver(schema.HTTPResolver()))
+func HTTPResolver() jsref.Resolver {
+	return jsref.NewHTTPResolver()
+}
+
+// FSResolver returns a resolver that reads references from fsys. It works
+// with any io/fs source — an embed.FS, os.DirFS, zip archive, etc. Pass it to
+// WithResolver to enable filesystem access:
+//
+//	r := schema.NewResolver(schema.WithResolver(schema.FSResolver(embedded)))
+//
+// References are looked up as slash-separated paths relative to the root of fsys
+// (a leading "/" and a "file://" scheme are stripped). JSON and YAML documents
+// are supported.
+func FSResolver(fsys fs.FS) jsref.Resolver {
+	return &fsResolver{fsys: fsys}
+}
+
+// DirResolver is shorthand for FSResolver(os.DirFS(dir)). It reads references
+// from the local directory tree rooted at dir (e.g. "." for the current working
+// directory):
+//
+//	r := schema.NewResolver(schema.WithResolver(schema.DirResolver(".")))
+func DirResolver(dir string) jsref.Resolver {
+	return FSResolver(os.DirFS(dir))
+}
+
+// fsResolver resolves references against an io/fs filesystem. jsref's own
+// filesystem resolver is path-only (built on os.OpenRoot) and cannot take an
+// fs.FS, so this small resolver bridges the gap, mirroring jsref's load → parse
+// → resolve-fragment flow.
+type fsResolver struct {
+	fsys fs.FS
+}
+
+func (r *fsResolver) CanResolve(resource any) bool {
+	s, ok := resource.(string)
+	if !ok || strings.HasPrefix(s, "#") {
+		return false
+	}
+	// Decline URLs with a network scheme so HTTPResolver handles those instead.
+	if u, err := url.Parse(s); err == nil && (u.Scheme == "http" || u.Scheme == "https") {
+		return false
+	}
+	return true
+}
+
+func (r *fsResolver) Resolve(dst any, resource any, localRef string) error {
+	p, ok := resource.(string)
+	if !ok {
+		return fmt.Errorf("fsResolver requires string resource, got %T", resource)
+	}
+
+	// Accept "file://" URLs by extracting their path component.
+	if u, err := url.Parse(p); err == nil && u.Scheme == "file" {
+		p = u.Path
+	}
+
+	// fs.FS uses unrooted, slash-separated, cleaned paths.
+	p = path.Clean(strings.TrimPrefix(p, "/"))
+
+	data, err := fs.ReadFile(r.fsys, p)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", p, err)
+	}
+
+	parsed, err := parseDocument(data)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s: %w", p, err)
+	}
+
+	if localRef == "" {
+		localRef = "#"
+	}
+	return jsref.NewObjectResolver().Resolve(dst, parsed, localRef)
+}
+
+// parseDocument decodes a schema document, accepting both JSON and YAML (YAML is
+// a JSON superset, and the path-based jsref resolver this replaces accepted
+// both). JSON is tried first to preserve JSON number semantics; YAML is the
+// fallback.
+func parseDocument(data []byte) (any, error) {
+	var parsed any
+	if err := json.Unmarshal(data, &parsed); err == nil {
+		return parsed, nil
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("not valid JSON or YAML: %w", err)
+	}
+	return parsed, nil
+}

--- a/resolver_options_test.go
+++ b/resolver_options_test.go
@@ -1,0 +1,58 @@
+package schema_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolverExternalAccessOptIn documents the core contract: NewResolver
+// resolves only from memory by default, and network/filesystem access must be
+// opted into explicitly via WithResolver.
+func TestResolverExternalAccessOptIn(t *testing.T) {
+	t.Run("network", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"$id":"https://example.com/person","type":"object"}`))
+		}))
+		defer server.Close()
+		ref := server.URL + "/person.json"
+
+		t.Run("declined by default", func(t *testing.T) {
+			var resolved schema.Schema
+			err := schema.NewResolver().ResolveReference(t.Context(), &resolved, ref, nil, "")
+			require.Error(t, err, "bare resolver must not fetch over the network")
+		})
+
+		t.Run("allowed with WithResolver(HTTPResolver())", func(t *testing.T) {
+			r := schema.NewResolver(schema.WithResolver(schema.HTTPResolver()))
+			var resolved schema.Schema
+			require.NoError(t, r.ResolveReference(t.Context(), &resolved, ref, nil, ""))
+			require.True(t, resolved.ContainsType(schema.ObjectType))
+		})
+	})
+
+	t.Run("filesystem", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"schemas/person.json": &fstest.MapFile{Data: []byte(`{"$id":"https://example.com/person","type":"string"}`)},
+		}
+		const ref = "schemas/person.json"
+
+		t.Run("declined by default", func(t *testing.T) {
+			var resolved schema.Schema
+			err := schema.NewResolver().ResolveReference(t.Context(), &resolved, ref, nil, "")
+			require.Error(t, err, "bare resolver must not read the filesystem")
+		})
+
+		t.Run("allowed with WithResolver(FSResolver(fsys))", func(t *testing.T) {
+			r := schema.NewResolver(schema.WithResolver(schema.FSResolver(fsys)))
+			var resolved schema.Schema
+			require.NoError(t, r.ResolveReference(t.Context(), &resolved, ref, nil, ""))
+			require.True(t, resolved.ContainsType(schema.StringType))
+		})
+	})
+}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -105,7 +105,7 @@ func TestResolveFileReference(t *testing.T) {
 	// Change to tmpDir for relative path resolution
 	t.Chdir(tmpDir)
 
-	resolver := schema.NewResolver()
+	resolver := schema.NewResolver(schema.WithResolver(schema.DirResolver(".")))
 
 	t.Run("resolve file reference", func(t *testing.T) {
 		var resolved schema.Schema
@@ -157,7 +157,7 @@ func TestResolveHTTPReference(t *testing.T) {
 	}))
 	defer server.Close()
 
-	resolver := schema.NewResolver()
+	resolver := schema.NewResolver(schema.WithResolver(schema.HTTPResolver()))
 
 	t.Run("resolve HTTP reference", func(t *testing.T) {
 		var resolved schema.Schema
@@ -240,7 +240,7 @@ $defs:
 	// Change to tmpDir for relative path resolution
 	t.Chdir(tmpDir)
 
-	resolver := schema.NewResolver()
+	resolver := schema.NewResolver(schema.WithResolver(schema.DirResolver(".")))
 
 	t.Run("resolve YAML file", func(t *testing.T) {
 		var resolved schema.Schema
@@ -455,7 +455,7 @@ func TestResolverSeparateAPIs(t *testing.T) {
 		}))
 		defer server.Close()
 
-		resolver := schema.NewResolver()
+		resolver := schema.NewResolver(schema.WithResolver(schema.HTTPResolver()))
 
 		// Test ResolveJSONReference with external URL and JSON pointer
 		var resolved schema.Schema

--- a/validator/metaschema_validation_test.go
+++ b/validator/metaschema_validation_test.go
@@ -141,7 +141,8 @@ func TestMetaschemaValidation(t *testing.T) {
 			t.Logf("AllOf length: %d", len(metaschemaRef.AllOf()))
 		}
 
-		v, err := validator.Compile(context.Background(), &metaschemaRef)
+		v, err := validator.Compile(context.Background(), &metaschemaRef,
+			validator.WithResolver(schema.NewResolver(schema.WithResolver(schema.HTTPResolver()))))
 		require.NoError(t, err)
 		t.Logf("Compiled validator type: %T", v)
 
@@ -189,7 +190,8 @@ func TestMetaschemaValidation(t *testing.T) {
 			t.Logf("AllOf length: %d", len(metaschemaRef.AllOf()))
 		}
 
-		v, err := validator.Compile(context.Background(), &metaschemaRef)
+		v, err := validator.Compile(context.Background(), &metaschemaRef,
+			validator.WithResolver(schema.NewResolver(schema.WithResolver(schema.HTTPResolver()))))
 		require.NoError(t, err)
 
 		// IMPORTANT: This uses map[string]any to represent the raw JSON data from the test suite.
@@ -238,7 +240,8 @@ func TestMetaschemaValidation(t *testing.T) {
 			t.Logf("AllOf length: %d", len(metaschemaRef.AllOf()))
 		}
 
-		v, err := validator.Compile(context.Background(), &metaschemaRef)
+		v, err := validator.Compile(context.Background(), &metaschemaRef,
+			validator.WithResolver(schema.NewResolver(schema.WithResolver(schema.HTTPResolver()))))
 		require.NoError(t, err)
 
 		// This uses map[string]any for a valid schema that should pass metaschema validation.


### PR DESCRIPTION
- `schema.NewResolver()` now resolves references **in-memory only**; network/filesystem access is opt-in (prevents surprise SSRF/disk reads). **Breaking** for callers relying on automatic external `$ref` fetching.
- Opt in via `WithResolver(HTTPResolver())`, `WithResolver(DirResolver(dir))`, or `WithResolver(FSResolver(fs.FS))` (io/fs-backed, JSON+YAML).
- Loud docs: README admonition, references guide callout, FAQ; new runnable example (`examples/resolver_optin_example_test.go`).
- Fixed stale context-bag docs left over from the options refactor.
