### PR TITLE
fix uniqueItems quadratic blowup

### DIFF
--- a/validator/array.go
+++ b/validator/array.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -325,25 +326,42 @@ func (c *arrayValidator) evaluate(ctx context.Context, v any, st *evalState) (Re
 		return nil, fmt.Errorf(`invalid value passed to ArrayValidator: array length %d exceeds maximum items %d`, length, *c.maxItems)
 	}
 
-	// Check uniqueItems constraint
-	if c.uniqueItems && length > 0 {
+	// Check uniqueItems constraint.
+	//
+	// Rather than the naive O(n^2) pairwise comparison, bucket items by their
+	// canonical JSON encoding and only compare within a bucket. reflect.DeepEqual
+	// implies identical json.Marshal output, so the key never yields a false
+	// negative (no missed duplicate); it may collide for DeepEqual-unequal values
+	// (e.g. native int(1) vs float64(1.0), both encode as "1"), which is why a real
+	// duplicate is still confirmed with reflect.DeepEqual to preserve existing
+	// semantics. For JSON-decoded data (the untrusted path) a shared key implies
+	// equality, so the first within-bucket comparison returns immediately and the
+	// scan stays linear.
+	if c.uniqueItems && acc.length > 1 {
+		// json.Marshal never returns empty bytes for a valid value, so this
+		// sentinel cannot collide with a real key. Items that fail to marshal
+		// (exotic non-JSON values from reflection or a custom ArrayIndexResolver)
+		// land here and are compared among themselves.
+		const unmarshalableKey = "\x00unmarshalable"
+		seen := make(map[string][]any, acc.length)
 		for i := range acc.length {
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}
-			item1, err := acc.at(i)
+			item, err := acc.at(i)
 			if err != nil {
 				return nil, fmt.Errorf(`invalid value passed to ArrayValidator: failed to resolve item %d: %w`, i, err)
 			}
-			for j := i + 1; j < acc.length; j++ {
-				item2, err := acc.at(j)
-				if err != nil {
-					return nil, fmt.Errorf(`invalid value passed to ArrayValidator: failed to resolve item %d: %w`, j, err)
-				}
-				if reflect.DeepEqual(item1, item2) {
+			key := unmarshalableKey
+			if b, err := json.Marshal(item); err == nil {
+				key = string(b)
+			}
+			for _, prev := range seen[key] {
+				if reflect.DeepEqual(prev, item) {
 					return nil, fmt.Errorf(`invalid value passed to ArrayValidator: duplicate items found, uniqueItems violation`)
 				}
 			}
+			seen[key] = append(seen[key], item)
 		}
 	}
 

--- a/validator/array_test.go
+++ b/validator/array_test.go
@@ -2,6 +2,7 @@ package validator_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	schema "github.com/lestrrat-go/json-schema"
@@ -711,4 +712,36 @@ func TestArrayValidatorComprehensive(t *testing.T) {
 			})
 		}
 	})
+}
+
+// BenchmarkUniqueItems measures uniqueItems validation across array sizes. The
+// worst case for a naive O(n^2) implementation is an all-unique array (no early
+// termination), so that is what we feed it. Elements are float64 to mirror
+// JSON-decoded numbers.
+func BenchmarkUniqueItems(b *testing.B) {
+	for _, n := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			s, err := schema.NewBuilder().
+				Types(schema.ArrayType).
+				UniqueItems(true).
+				Build()
+			require.NoError(b, err)
+
+			v, err := validator.Compile(b.Context(), s)
+			require.NoError(b, err)
+
+			data := make([]any, n)
+			for i := range data {
+				data[i] = float64(i)
+			}
+
+			ctx := b.Context()
+			b.ResetTimer()
+			for range b.N {
+				if _, err := v.Validate(ctx, data); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
- `uniqueItems` validated via O(n²) pairwise `reflect.DeepEqual` — algorithmic-complexity DoS on the untrusted-instance path (~10⁴ elements ⇒ ~5×10⁷ comparisons)
- replace with hash-bucketed scan: key by canonical `json.Marshal`, confirm within-bucket with `reflect.DeepEqual` — preserves exact semantics (incl. native `int(1)` vs `float64(1.0)` distinction); linear on JSON-decoded data
- add `BenchmarkUniqueItems`: n=5000 drops 268 ms → 0.89 ms (~302×); all unit tests and 77 conformance `uniqueItems` cases pass
