### PR TITLE
fix builder error propagation in Build

### DIFF
--- a/builder_builderror_test.go
+++ b/builder_builderror_test.go
@@ -1,0 +1,44 @@
+package schema_test
+
+import (
+	"testing"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/stretchr/testify/require"
+)
+
+// A nil SchemaOrBool passed to an applicator setter records a builder error.
+// Build() must surface that error instead of silently dropping it, and
+// MustBuild() must panic rather than return a half-built schema.
+func TestBuilderErrorPropagation(t *testing.T) {
+	t.Run("Build returns the recorded error", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			build func() (*schema.Schema, error)
+		}{
+			{"AllOf", func() (*schema.Schema, error) { return schema.NewBuilder().AllOf(nil).Build() }},
+			{"AnyOf", func() (*schema.Schema, error) { return schema.NewBuilder().AnyOf(nil).Build() }},
+			{"OneOf", func() (*schema.Schema, error) { return schema.NewBuilder().OneOf(nil).Build() }},
+			{"PrefixItems", func() (*schema.Schema, error) { return schema.NewBuilder().PrefixItems(nil).Build() }},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				s, err := tc.build()
+				require.Error(t, err, "Build must propagate the builder error")
+				require.Nil(t, s, "Build must not return a schema on error")
+			})
+		}
+	})
+
+	t.Run("error is sticky across subsequent setters", func(t *testing.T) {
+		// Once an error is recorded, later setters are no-ops and Build still fails.
+		s, err := schema.NewBuilder().AllOf(nil).Types(schema.StringType).Build()
+		require.Error(t, err)
+		require.Nil(t, s)
+	})
+
+	t.Run("MustBuild panics on builder error", func(t *testing.T) {
+		require.Panics(t, func() {
+			schema.NewBuilder().AllOf(nil).MustBuild()
+		})
+	})
+}

--- a/builder_gen.go
+++ b/builder_gen.go
@@ -1410,6 +1410,9 @@ func (b *Builder) Reset(flags FieldFlag) *Builder {
 }
 
 func (b *Builder) Build() (*Schema, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
 	s := New()
 	if b.additionalItems != nil {
 		s.additionalItems = b.additionalItems

--- a/internal/cmd/genobjects/main.go
+++ b/internal/cmd/genobjects/main.go
@@ -612,6 +612,9 @@ func genBuilder(obj *codegen.Object) error {
 	o.L("}")
 
 	o.LL("func (b *Builder) Build() (*Schema, error) {")
+	o.L("if b.err != nil {")
+	o.L("return nil, b.err")
+	o.L("}")
 	o.L("s := New()")
 	for _, field := range obj.Fields() {
 		switch field.Type() {

--- a/validator/compiler.go
+++ b/validator/compiler.go
@@ -46,9 +46,15 @@ func combineReferenceWithConstraints(ctx context.Context, s *schema.Schema, cs c
 	if !hasOtherConstraints(s) {
 		return resolvedValidator, nil
 	}
-	schemaWithoutRef := createSchemaWithoutRef(s)
+	schemaWithoutRef, err := createSchemaWithoutRef(s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build schema without reference: %w", err)
+	}
 	if schemaWithoutRef.HasUnevaluatedProperties() || schemaWithoutRef.HasUnevaluatedItems() {
-		schemaWithoutUnevaluated := createSchemaWithoutUnevaluatedFields(schemaWithoutRef)
+		schemaWithoutUnevaluated, err := createSchemaWithoutUnevaluatedFields(schemaWithoutRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build schema without unevaluated fields: %w", err)
+		}
 		additionalValidator, err := compile(ctx, schemaWithoutUnevaluated, cs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to compile additional constraints: %w", err)
@@ -177,12 +183,18 @@ func compileSchema(ctx context.Context, s *schema.Schema, cs compileState) (Inte
 			}
 
 			// Create schema without reference for additional constraints
-			schemaWithoutRef := createSchemaWithoutRef(s)
+			schemaWithoutRef, err := createSchemaWithoutRef(s)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build schema without reference: %w", err)
+			}
 
 			// Check if we need unevaluated coordination
 			if schemaWithoutRef.HasUnevaluatedProperties() || schemaWithoutRef.HasUnevaluatedItems() {
 				// Create additional validator WITHOUT unevaluated constraints
-				schemaWithoutUnevaluated := createSchemaWithoutUnevaluatedFields(schemaWithoutRef)
+				schemaWithoutUnevaluated, err := createSchemaWithoutUnevaluatedFields(schemaWithoutRef)
+				if err != nil {
+					return nil, fmt.Errorf("failed to build schema without unevaluated fields: %w", err)
+				}
 				additionalValidator, err := compile(ctx, schemaWithoutUnevaluated, cs)
 				if err != nil {
 					return nil, fmt.Errorf("failed to compile additional constraints: %w", err)
@@ -413,7 +425,10 @@ func compileBaseConstraints(ctx context.Context, s *schema.Schema, cs compileSta
 					// Strip unevaluatedItems so the array validator does not
 					// self-enforce it; the unevaluatedCoordinator owns that
 					// decision once sibling applicators' annotations are merged.
-					baseSchema := createSchemaWithoutUnevaluatedFields(s)
+					baseSchema, err := createSchemaWithoutUnevaluatedFields(s)
+					if err != nil {
+						return nil, fmt.Errorf("failed to build schema without unevaluated fields: %w", err)
+					}
 					arrayValidator, err := compileArrayValidator(ctx, baseSchema, cs, true) // strict type checking
 					if err != nil {
 						return nil, fmt.Errorf("failed to compile array validator: %w", err)
@@ -428,7 +443,10 @@ func compileBaseConstraints(ctx context.Context, s *schema.Schema, cs compileSta
 				// Object type validator (excluding unevaluatedProperties)
 				objectFields := schema.ObjectConstraintFields &^ schema.UnevaluatedPropertiesField
 				if s.HasAny(objectFields) {
-					baseSchema := createSchemaWithoutUnevaluatedFields(s)
+					baseSchema, err := createSchemaWithoutUnevaluatedFields(s)
+					if err != nil {
+						return nil, fmt.Errorf("failed to build schema without unevaluated fields: %w", err)
+					}
 					objectValidator, err := compileObjectValidator(ctx, baseSchema, cs, true) // strict type checking
 					if err != nil {
 						return nil, fmt.Errorf("failed to compile object validator: %w", err)
@@ -477,7 +495,10 @@ func compileBaseConstraints(ctx context.Context, s *schema.Schema, cs compileSta
 		// Array constraints (excluding unevaluatedItems) without explicit type
 		arrayFields := schema.ArrayConstraintFields &^ schema.UnevaluatedItemsField
 		if s.HasAny(arrayFields) {
-			baseSchema := createSchemaWithoutUnevaluatedFields(s)
+			baseSchema, err := createSchemaWithoutUnevaluatedFields(s)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build schema without unevaluated fields: %w", err)
+			}
 			arrayValidator, err := compileArrayValidator(ctx, baseSchema, cs, false)
 			if err != nil {
 				return nil, fmt.Errorf("failed to compile array validator: %w", err)
@@ -488,7 +509,10 @@ func compileBaseConstraints(ctx context.Context, s *schema.Schema, cs compileSta
 		// Object constraints (excluding unevaluatedProperties) without explicit type
 		objectFields := schema.ObjectConstraintFields &^ schema.UnevaluatedPropertiesField
 		if s.HasAny(objectFields) {
-			baseSchema := createSchemaWithoutUnevaluatedFields(s)
+			baseSchema, err := createSchemaWithoutUnevaluatedFields(s)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build schema without unevaluated fields: %w", err)
+			}
 			objectValidator, err := compileObjectValidator(ctx, baseSchema, cs, false)
 			if err != nil {
 				return nil, fmt.Errorf("failed to compile object validator: %w", err)
@@ -606,12 +630,12 @@ func compileValueConstraintsValidator(_ context.Context, s *schema.Schema) (Inte
 // Helper functions for schema manipulation and type strictness detection
 
 // createSchemaWithoutUnevaluatedFields creates a copy of the schema without unevaluated constraints
-func createSchemaWithoutUnevaluatedFields(s *schema.Schema) *schema.Schema {
+func createSchemaWithoutUnevaluatedFields(s *schema.Schema) (*schema.Schema, error) {
 	// Use the builder to clone the schema and reset unevaluated fields
 	builder := schema.NewBuilder().Clone(s)
 	builder.ResetUnevaluatedProperties()
 	builder.ResetUnevaluatedItems()
-	return builder.MustBuild()
+	return builder.Build()
 }
 
 func hasExplicitArrayType(s *schema.Schema) bool {

--- a/validator/composite_validator_test.go
+++ b/validator/composite_validator_test.go
@@ -31,7 +31,8 @@ func TestCompositeValidatorWithRefAndOtherConstraints(t *testing.T) {
 	require.True(t, hasOtherConstraints(schemaWithRef))
 
 	// Test the createSchemaWithoutRef function
-	withoutRef := createSchemaWithoutRef(schemaWithRef)
+	withoutRef, err := createSchemaWithoutRef(schemaWithRef)
+	require.NoError(t, err)
 	require.False(t, withoutRef.HasReference())
 	require.True(t, withoutRef.HasMaxLength())
 	require.True(t, withoutRef.HasPattern())

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -205,13 +205,13 @@ func hasOtherConstraints(s *schema.Schema) bool {
 }
 
 // createSchemaWithoutRef creates a copy of the schema without the $ref/$dynamicRef constraint
-func createSchemaWithoutRef(s *schema.Schema) *schema.Schema {
+func createSchemaWithoutRef(s *schema.Schema) (*schema.Schema, error) {
 	// Use the new Clone Builder pattern to create a copy without the $ref/$dynamicRef field
 	builder := schema.NewBuilder().Clone(s).ResetReference()
 	if s.HasDynamicReference() {
 		builder = builder.ResetDynamicReference()
 	}
-	return builder.MustBuild()
+	return builder.Build()
 }
 
 // mergeGenericResults merges two results, handling both ObjectResult and ArrayResult types


### PR DESCRIPTION
- `Build()` now checks `b.err` first, so validation errors from `AllOf`/`AnyOf`/`OneOf`/`PrefixItems` (e.g. nil `SchemaOrBool`) are surfaced instead of silently dropped (generator + regenerated `builder_gen.go`).
- `createSchemaWithoutRef` / `createSchemaWithoutUnevaluatedFields` return `(*schema.Schema, error)` and propagate through the compile pipeline, removing the `MustBuild()` panic that broke `Compile`'s `(Interface, error)` contract.
- Added builder-error-propagation test; full conformance suite stays green.
