### PR TITLE
handle structs in DependentSchemasValidator

### DIFF
--- a/validator/dependent_schemas.go
+++ b/validator/dependent_schemas.go
@@ -38,9 +38,14 @@ func (v *dependentSchemasValidator) Validate(ctx context.Context, value any, opt
 }
 
 func (v *dependentSchemasValidator) evaluate(ctx context.Context, value any, st *evalState) (Result, error) {
-	// dependentSchemas only applies to objects
-	obj, ok := value.(map[string]any)
-	if !ok {
+	// dependentSchemas only applies to objects. Reuse the object validator's
+	// extraction so structs and ObjectFieldResolvers are handled identically,
+	// instead of only accepting map[string]any.
+	obj, isObject, err := extractObjectProperties(value)
+	if err != nil {
+		return nil, fmt.Errorf("dependent schema validation failed: %w", err)
+	}
+	if !isObject {
 		//nolint: nilnil
 		return nil, nil
 	}
@@ -49,8 +54,7 @@ func (v *dependentSchemasValidator) evaluate(ctx context.Context, value any, st 
 	for propertyName, depValidator := range v.dependentSchemas {
 		// If the property exists in the object, validate the entire object with the dependent schema
 		if _, exists := obj[propertyName]; exists {
-			_, err := evalChild(ctx, depValidator, value, st)
-			if err != nil {
+			if _, err := evalChild(ctx, depValidator, value, st); err != nil {
 				return nil, fmt.Errorf("dependent schema validation failed for property %s: %w", propertyName, err)
 			}
 		}

--- a/validator/dependent_schemas_test.go
+++ b/validator/dependent_schemas_test.go
@@ -164,6 +164,49 @@ func TestDependentSchemas(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("isolation: struct input to direct validator", func(t *testing.T) {
+		// The standalone DependentSchemasValidator (public API, not used by the
+		// Compile path) must handle Go structs the same way the object validator
+		// does, rather than silently skipping anything that is not map[string]any.
+		// Struct fields are always present after extraction regardless of
+		// omitempty, so the trigger property is always present; this exercises
+		// the dependent schema's type constraint.
+		dependentSchemaJSON := `{
+			"properties": {
+				"bar": {"type": "string"}
+			}
+		}`
+
+		var depSchema schema.Schema
+		require.NoError(t, depSchema.UnmarshalJSON([]byte(dependentSchemaJSON)))
+
+		ctx := context.Background()
+		v, err := validator.DependentSchemasValidator(ctx, map[string]*schema.Schema{"foo": &depSchema})
+		require.NoError(t, err)
+
+		// Invalid - foo triggers the dependency, but bar violates type:string.
+		// Before the fix the struct was not a map[string]any, so it was silently
+		// skipped and this passed.
+		type badDoc struct {
+			Foo int `json:"foo"`
+			Bar int `json:"bar"`
+		}
+		_, err = v.Validate(ctx, badDoc{Foo: 1, Bar: 2})
+		require.Error(t, err)
+
+		// A pointer to the struct must behave identically.
+		_, err = v.Validate(ctx, &badDoc{Foo: 1, Bar: 2})
+		require.Error(t, err)
+
+		// Valid - foo triggers the dependency, bar is a string.
+		type goodDoc struct {
+			Foo int    `json:"foo"`
+			Bar string `json:"bar"`
+		}
+		_, err = v.Validate(ctx, goodDoc{Foo: 1, Bar: "ok"})
+		require.NoError(t, err)
+	})
+
 	t.Run("dependent schemas with references", func(t *testing.T) {
 		jsonSchema := `{
 			"type": "object",


### PR DESCRIPTION
- `DependentSchemasValidator` extracted object properties only from `map[string]any`, silently skipping Go structs, `*struct`, and `ObjectFieldResolver` inputs
- route it through `extractObjectProperties`, matching the object validator (the `Compile` path was already correct; only the standalone public API was affected)
- add direct-validator regression test covering struct and pointer inputs
