### PR TITLE
fix panic on empty PrimitiveTypes.UnmarshalJSON

### DIFF
--- a/primitives.go
+++ b/primitives.go
@@ -107,7 +107,7 @@ type PrimitiveTypes []PrimitiveType
 
 // UnmarshalJSON initializes the list of primitive types
 func (pt *PrimitiveTypes) UnmarshalJSON(data []byte) error {
-	if data[0] != '[' {
+	if len(data) == 0 || data[0] != '[' {
 		var t PrimitiveType
 		if err := json.Unmarshal(data, &t); err != nil {
 			return err

--- a/primitives_scalar_test.go
+++ b/primitives_scalar_test.go
@@ -31,3 +31,13 @@ func TestIsScalarPrimitiveType(t *testing.T) {
 		require.False(t, schema.IsScalarPrimitiveType(typ), "%s should not be scalar", typ)
 	}
 }
+
+// A direct UnmarshalJSON call with empty input must return an error rather than
+// panicking on data[0] (encoding/json never feeds empty data to UnmarshalJSON,
+// but the method is exported and can be called directly).
+func TestPrimitiveTypesUnmarshalEmpty(t *testing.T) {
+	var pt schema.PrimitiveTypes
+	require.NotPanics(t, func() {
+		require.Error(t, pt.UnmarshalJSON([]byte{}))
+	})
+}


### PR DESCRIPTION
- `PrimitiveTypes.UnmarshalJSON` indexed `data[0]` with no length guard, panicking on a direct call with empty input
- guard routes empty input to the scalar path, returning json's "unexpected end of JSON input" error
- add regression test
