### PR TITLE
add ValidateJSON with json.Number precision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Single Go module, `github.com/lestrrat-go/json-schema`, with sub-packages:
 | Import path | Directory | Responsibility |
 |-------------|-----------|----------------|
 | `github.com/lestrrat-go/json-schema` | `/` (root) | Schema data type + fluent builder (the `schema` package) |
-| `.../validator` | `validator/` | Compile schemas into validators; run validation; generate validator code |
+| `.../validator` | `validator/` | Compile schemas into validators; run validation; raw-JSON `ValidateJSON`; generate validator code |
 | `.../vocabulary` | `vocabulary/` | 2020-12 vocabularies and per-context enable/disable |
 | `.../keywords` | `keywords/` | String constants for every JSON Schema keyword |
 | `.../meta` | `meta/` | Pre-compiled 2020-12 meta-schema validator |
@@ -45,15 +45,16 @@ See [`agents/docs/packages.md`](agents/docs/packages.md) for the full exported-A
 |----------------|------------------|-------|
 | `schema_gen.go`, `builder_gen.go` | `internal/cmd/genobjects/` | `internal/cmd/genobjects/objects.yml` |
 | `meta/meta_gen.go` | `internal/cmd/genmeta/` | embedded 2020-12 meta-schema (no network) |
-| `validator/int_gen.go`, `validator/number_gen.go` | numeric-validator generator | — |
+| `validator/int_gen.go`, `validator/number_gen.go` | `validator/internal/cmd/gennumeric/` | — |
 
 ### Regenerate
 
 ```bash
-./gen.sh
+./gen.sh            # schema/builder (genobjects) + meta validator (genmeta)
+validator/gen.sh    # numeric validators (gennumeric) — NOT run by ./gen.sh
 ```
 
-`gen.sh` builds and runs `genobjects` (schema + builder) and `genmeta` (meta validator), then removes the temporary generator binaries. It must be run from anywhere — it `cd`s to its own directory. See [`agents/docs/codegen.md`](agents/docs/codegen.md) for what each generator emits and how validator code generation (the `gen-validator` CLI path) differs from object generation.
+`gen.sh` builds and runs `genobjects` (schema + builder) and `genmeta` (meta validator), then removes the temporary generator binaries. The numeric validators (`int_gen.go`/`number_gen.go`) are regenerated separately by `validator/gen.sh`; the emitted `Validate` methods depend on the hand-written helpers in `validator/numeric.go`. Both scripts `cd` to their own directory, so they run from anywhere. See [`agents/docs/codegen.md`](agents/docs/codegen.md) for what each generator emits and how validator code generation (the `gen-validator` CLI path) differs from object generation.
 
 When you edit an `_gen.go` file's generator, commit **both** the generator change and the regenerated output.
 

--- a/agents/docs/architecture.md
+++ b/agents/docs/architecture.md
@@ -33,6 +33,14 @@ Why it matters when editing:
 
 The output is a tree of small validators. `Interface.Validate(ctx, value)` runs the tree, returning `(Result, error)`; a non-nil error is a validation failure with a descriptive message.
 
+`validator.ValidateJSON(ctx, v, data)` (validator/json.go) is a thin convenience entry for raw JSON bytes: it decodes `data` with `json.Decoder.UseNumber()` (rejecting empty input and trailing data) and delegates to `v.Validate`. It's a free function (not an `Interface` method) because `Interface` is the recursive tree-node contract implemented by ~20 validators, and decoding is a top-level concern, not a per-node one.
+
+Object values are read through one shared helper, `extractObjectProperties` (validator/object.go), used by the object validator, `dependentSchemas`, and the unevaluated coordinator (`resolveToObjectMap`). It fast-paths a `map[string]any` (the JSON-decoded shape) by returning it directly — callers treat the result as read-only, so no copy is made — then handles `ObjectFieldResolver`, other map kinds, and structs (via `json` tags). `newArrayAccessor` (validator/array.go) does the same for `[]any`. Consequence: keywords like `unevaluatedProperties` apply uniformly to maps, structs, and `ObjectFieldResolver` values, not only `map[string]any`.
+
+## Numeric values and `json.Number`
+
+Because `ValidateJSON` uses `UseNumber`, numbers can reach the validators as `json.Number` (a named *string* type, so its `reflect.Kind` is `String`). All numeric type detection is therefore centralized in `validator/numeric.go` — `isNumeric`, `isJSONNumber`, `numericFloat`, `numericInt` — which accept both native Go numeric kinds (from `json.Unmarshal`, struct fields, builder literals) and `json.Number`. The generated integer/number validators and the hand-written `inferredNumberValidator`/`convertToNumber` all route through these helpers; the string validator calls `isJSONNumber` to *exclude* a number that would otherwise look like a string. The integer validator stores constraints as `int64`, and `numericInt` preserves precision via `json.Number.Int64()` (exact up to 2^63); integer-valued numbers outside the `int64` range are reported as an error rather than silently truncated.
+
 ## Context, not globals
 
 State that must flow through compilation and validation is carried on `context.Context`, never in package globals. This keeps `Compile`/`Validate` reentrant and concurrency-safe. Key carriers:

--- a/agents/docs/codegen.md
+++ b/agents/docs/codegen.md
@@ -13,15 +13,17 @@ Turns a YAML description of the schema keyword set into the `Schema` data type a
 | `schema_gen.go` (the `Schema` struct, accessors, field flags, `MarshalJSON`/`UnmarshalJSON`) | `internal/cmd/genobjects/` | `internal/cmd/genobjects/objects.yml` |
 | `builder_gen.go` (the `Builder`, one chainable method + `ResetXxx` per keyword) | `internal/cmd/genobjects/` | same |
 | `meta/meta_gen.go` (the `metaValidator` value) | `internal/cmd/genmeta/` | meta-schema embedded in the generator (no network) |
-| `validator/int_gen.go`, `validator/number_gen.go` | numeric-validator generator | — |
+| `validator/int_gen.go`, `validator/number_gen.go` | `validator/internal/cmd/gennumeric/` | — (both files driven by one `definition`; the integer one differs only by type `int64`/class `Integer`) |
 
-Run everything with:
+Run the root generators with:
 
 ```bash
 ./gen.sh
 ```
 
-`gen.sh` builds `genobjects`, runs it against `objects.yml`, builds `genmeta`, runs it, and deletes both temporary binaries. To add or change a schema keyword: edit `objects.yml` (and the generator if the shape is new), run `gen.sh`, commit generator + regenerated `_gen.go` together. **Never hand-edit `_gen.go`.**
+`gen.sh` builds `genobjects`, runs it against `objects.yml`, builds `genmeta`, runs it, and deletes both temporary binaries. **It does NOT run the numeric generator.** The numeric validators have their own script — run `validator/gen.sh` (builds and runs `gennumeric`, then removes the binary) when you change `gennumeric/main.go`. To add or change a schema keyword: edit `objects.yml` (and the generator if the shape is new), run `gen.sh`, commit generator + regenerated `_gen.go` together. **Never hand-edit `_gen.go`.**
+
+`gennumeric`'s emitted `Validate` methods call the hand-written helpers in `validator/numeric.go` (`numericInt` for the integer validator, `numericFloat` for the number validator) instead of switching on `reflect.Kind` inline — this is what lets a `json.Number` (UseNumber) validate like a native number. `numeric.go` must exist for the generated files to compile.
 
 `meta/meta.go` is hand-written and owns the public `Validator()` / `Validate()`; `genmeta` only emits the `metaValidator` value it wraps. This split exists so the meta validator can register itself under the `"meta"` dynamic anchor (see references.md) — logic that does not belong in generated output.
 

--- a/agents/docs/packages.md
+++ b/agents/docs/packages.md
@@ -27,9 +27,10 @@ Compile schemas to validators; validate; generate validator code.
 
 - **Interface** — `Validate(ctx context.Context, value any) (Result, error)`. Non-nil error == validation failure (validator.go).
 - **Result** — `type Result = any`. Annotation payload (e.g. `*ObjectResult`, `*ArrayResult`) used to track evaluated properties/items for `unevaluated*`.
-- **Compile(ctx context.Context, s *schema.Schema) (Interface, error)** (compiler.go) — single entry point. Sets up resolver/root/base/vocabulary in ctx; rebases `$id`; wraps `$dynamicAnchor` schemas in a `dynamicScopeValidator`.
+- **Compile(ctx context.Context, s *schema.Schema, ...CompileOption) (Interface, error)** (compiler.go) — single entry point. Sets up resolver/root/base/vocabulary in ctx; rebases `$id`; wraps `$dynamicAnchor` schemas in a `dynamicScopeValidator`.
+- **ValidateJSON(ctx, v Interface, data []byte, ...ValidateOption) (Result, error)** (json.go) — decode raw JSON (`UseNumber`, rejecting empty/trailing input) and validate via `v`. Numbers stay `json.Number` so large integers keep precision; helpers in `numeric.go` (`isNumeric`/`isJSONNumber`/`numericFloat`/`numericInt`) interpret them.
 - Hand-written validator builders (each `Build()/MustBuild()`): **Object()** (`*ObjectValidatorBuilder`: `Properties()`, `PatternProperties()`, `AdditionalProperties()`, `PropertyNames()`, `Required()`, `DependentRequired()`, `DependentSchemas()`, `Min/MaxProperties()`, `UnevaluatedProperties()`, `StrictObjectType()`), **String()** (`MinLength/MaxLength/Pattern/Format`), **Array()** (`Items/PrefixItems/Contains/Min/MaxItems/UniqueItems/Min/MaxContains/AdditionalItems/UnevaluatedItems`), **Boolean()**, **Null() Interface**.
-- Generated numeric builders: **Integer()** (`*IntegerValidatorBuilder`), **Number()** — `Minimum/Maximum/ExclusiveMinimum/ExclusiveMaximum/MultipleOf` (`int_gen.go`, `number_gen.go`).
+- Generated numeric builders: **Integer()** (`*IntegerValidatorBuilder`; methods take `int64`), **Number()** (`float64`) — `Minimum/Maximum/ExclusiveMinimum/ExclusiveMaximum/MultipleOf` (`int_gen.go`, `number_gen.go`).
 - **PropPair(name string, v Interface) PropertyPair** — for `ObjectValidatorBuilder.Properties(...)` (object.go).
 - Composition (multi.go): **AllOf/AnyOf/OneOf(...Interface) Interface**.
 - Code generation: **CodeGenerator** interface — `Generate(dst io.Writer, v Interface) error`; **NewCodeGenerator() CodeGenerator** (codegen_core.go). Emits Go builder source from a compiled validator.

--- a/agents/docs/testing.md
+++ b/agents/docs/testing.md
@@ -21,6 +21,8 @@ If `tests/` is missing, `TestSpecificationCompliance` finds no cases. Run `init-
 - Remote refs: the suite's `tests/remotes/` tree is preloaded via the resolver (`loadRemotes` / `newSuiteResolver`) and served logically at `http://localhost:1234/...`, so `$ref`s to remotes resolve offline. This uses `Resolver.RegisterDocument` (see references.md).
 - Status: the entire **required** 2020-12 suite passes (1723 pass / 0 fail / 0 skip at last count). A new failure in this test is a real regression, not a flaky case.
 
+The suite is decoded with the default `json.Unmarshal` (numbers become `float64`), which exercises the native-numeric path. The `json.Number` path used by `validator.ValidateJSON` (UseNumber decode) is not run against the full suite; it is covered by targeted tests instead — `validator/numeric_test.go` (the `numericInt`/`numericFloat`/`isNumeric` helpers, including large-int and exponent forms) and `validator/json_test.go` (`ValidateJSON` end to end: malformed/trailing/empty input, integer precision, const/enum, multi-type). If you change numeric handling, both paths must stay in agreement. `validator/json_bench_test.go` benchmarks unmarshal-then-validate vs `ValidateJSON`.
+
 Other top-level tests are hand-written feature tests (`schema_references_test.go`, `resolver_test.go`, `schema_metaschema_test.go`, `boolean_schema_test.go`, the `validator/` package tests, the `meta/` tests, etc.). Runnable usage examples live in `examples/` as Go `Example` functions and table tests.
 
 ## Running

--- a/docs/02-validating.md
+++ b/docs/02-validating.md
@@ -6,7 +6,7 @@ Validation is two steps: **compile** a schema into a validator, then **validate*
 
 `validator.Compile(ctx, s)` returns a `validator.Interface`. Compiling walks the schema once and is the expensive step; the returned validator is safe to **reuse across goroutines** and across many `Validate` calls. Do the compile at startup, keep the `Interface` around, and call `Validate(ctx, data)` per request.
 
-`data` is any decoded JSON value — `map[string]any`, `[]any`, `string`, `float64`, `bool`, `nil`, etc. (the shapes `encoding/json` produces into an `any`).
+`data` is any decoded JSON value — `map[string]any`, `[]any`, `string`, `float64`, `bool`, `nil`, etc. (the shapes `encoding/json` produces into an `any`). To validate raw JSON text without decoding it yourself first, see [Validating raw JSON text](#validating-raw-json-text).
 
 ## Reading the result
 
@@ -63,6 +63,63 @@ func Example_docValidate() {
 }
 ```
 source: [examples/doc_validate_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/doc_validate_test.go)
+<!-- END INCLUDE -->
+
+## Validating raw JSON text
+
+If you start from JSON bytes, `validator.ValidateJSON(ctx, v, data)` decodes and validates in one call — no manual `json.Unmarshal` step. It uses the same compiled validator, so the compile-once / validate-many guidance above still applies; only the decoding differs.
+
+Two things to know:
+
+- **Numbers keep their precision.** `ValidateJSON` decodes with `json.Decoder.UseNumber()`, so a 64-bit identifier larger than 2^53 is validated exactly instead of being rounded by `float64`. (Integer values outside the `int64` range cannot be validated as integers and are reported as an error.)
+- **Exactly one value.** The input must contain a single top-level JSON value; trailing content after it (other than whitespace) is rejected. Empty or whitespace-only input is an error.
+
+<!-- INCLUDE(examples/validate_json_example_test.go) -->
+```go
+package examples_test
+
+import (
+  "context"
+  "fmt"
+
+  schema "github.com/lestrrat-go/json-schema"
+  "github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_validateJSON validates raw JSON text directly with
+// validator.ValidateJSON, skipping a manual json.Unmarshal step. Numbers are
+// decoded as json.Number, so a 64-bit identifier larger than 2^53 is validated
+// exactly rather than being rounded by float64.
+func Example_validateJSON() {
+  s := schema.NewBuilder().
+    Types(schema.ObjectType).
+    Property("id", schema.NewBuilder().Types(schema.IntegerType).MustBuild()).
+    Property("role", schema.Enum("admin", "user").MustBuild()).
+    Required("id", "role").
+    MustBuild()
+
+  ctx := context.Background()
+  v, err := validator.Compile(ctx, s)
+  if err != nil {
+    fmt.Println("compile failed:", err)
+    return
+  }
+
+  for _, data := range [][]byte{
+    []byte(`{"id": 9007199254740993, "role": "admin"}`), // large id, valid
+    []byte(`{"id": 1, "role": "root"}`),                  // role not in enum
+    []byte(`{"role": "admin"}`),                          // missing required id
+  } {
+    _, err := validator.ValidateJSON(ctx, v, data)
+    fmt.Printf("valid=%t\n", err == nil)
+  }
+  // Output:
+  // valid=true
+  // valid=false
+  // valid=false
+}
+```
+source: [examples/validate_json_example_test.go](https://github.com/lestrrat-go/json-schema/blob/main/examples/validate_json_example_test.go)
 <!-- END INCLUDE -->
 
 ## Configuring Compile and Validate

--- a/docs/99-faq.md
+++ b/docs/99-faq.md
@@ -8,6 +8,10 @@ That's the JSON Schema 2020-12 default: `format` is an **annotation**, not an as
 
 `Compile` once, keep the returned `validator.Interface`, and call `Validate` as often as you like. Compilation is the expensive step; the compiled validator is safe to reuse across goroutines. See [Validating Data](./02-validating.md).
 
+### How do I validate a JSON byte slice, or keep large integers precise?
+
+Call `validator.ValidateJSON(ctx, v, data)` with the raw `[]byte` instead of unmarshaling yourself. It decodes with `json.Decoder.UseNumber()`, so integers larger than 2^53 (e.g. 64-bit IDs) are validated exactly rather than being rounded by `float64`; integers outside the `int64` range are reported as an error. The input must be a single top-level JSON value with no trailing data. See [Validating raw JSON text](./02-validating.md#validating-raw-json-text).
+
 ### Can I just unmarshal a schema from JSON instead of building it?
 
 Yes. `*schema.Schema` implements `json.Unmarshaler`, so `json.Unmarshal(buf, &s)` is all it takes. A schema loaded from JSON and one built with `NewBuilder()` behave identically. See [Building Schemas](./01-building-schemas.md).

--- a/examples/validate_json_example_test.go
+++ b/examples/validate_json_example_test.go
@@ -1,0 +1,42 @@
+package examples_test
+
+import (
+	"context"
+	"fmt"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+)
+
+// Example_validateJSON validates raw JSON text directly with
+// validator.ValidateJSON, skipping a manual json.Unmarshal step. Numbers are
+// decoded as json.Number, so a 64-bit identifier larger than 2^53 is validated
+// exactly rather than being rounded by float64.
+func Example_validateJSON() {
+	s := schema.NewBuilder().
+		Types(schema.ObjectType).
+		Property("id", schema.NewBuilder().Types(schema.IntegerType).MustBuild()).
+		Property("role", schema.Enum("admin", "user").MustBuild()).
+		Required("id", "role").
+		MustBuild()
+
+	ctx := context.Background()
+	v, err := validator.Compile(ctx, s)
+	if err != nil {
+		fmt.Println("compile failed:", err)
+		return
+	}
+
+	for _, data := range [][]byte{
+		[]byte(`{"id": 9007199254740993, "role": "admin"}`), // large id, valid
+		[]byte(`{"id": 1, "role": "root"}`),                  // role not in enum
+		[]byte(`{"role": "admin"}`),                          // missing required id
+	} {
+		_, err := validator.ValidateJSON(ctx, v, data)
+		fmt.Printf("valid=%t\n", err == nil)
+	}
+	// Output:
+	// valid=true
+	// valid=false
+	// valid=false
+}

--- a/examples/validate_json_example_test.go
+++ b/examples/validate_json_example_test.go
@@ -29,8 +29,8 @@ func Example_validateJSON() {
 
 	for _, data := range [][]byte{
 		[]byte(`{"id": 9007199254740993, "role": "admin"}`), // large id, valid
-		[]byte(`{"id": 1, "role": "root"}`),                  // role not in enum
-		[]byte(`{"role": "admin"}`),                          // missing required id
+		[]byte(`{"id": 1, "role": "root"}`),                 // role not in enum
+		[]byte(`{"role": "admin"}`),                         // missing required id
 	} {
 		_, err := validator.ValidateJSON(ctx, v, data)
 		fmt.Printf("valid=%t\n", err == nil)

--- a/validator/array.go
+++ b/validator/array.go
@@ -271,6 +271,12 @@ type arrayAccessor struct {
 // newArrayAccessor honors a custom ArrayIndexResolver first, then falls back to
 // reflection. The bool reports whether v is array-like at all.
 func newArrayAccessor(v any) (arrayAccessor, bool) {
+	// Fast path for the standard JSON-decoded shape: index the slice directly
+	// instead of reflecting on each element.
+	if s, ok := v.([]any); ok {
+		return arrayAccessor{length: len(s), at: func(i int) (any, error) { return s[i], nil }}, true
+	}
+
 	if resolver, ok := v.(ArrayIndexResolver); ok {
 		return arrayAccessor{length: resolver.Len(), at: resolver.ResolveArrayIndex}, true
 	}

--- a/validator/generator.go
+++ b/validator/generator.go
@@ -295,7 +295,7 @@ func (g *codeGenerator) generateInteger(dst io.Writer, v *integerValidator) erro
 		for i, n := range v.enum {
 			strs[i] = fmt.Sprintf("%d", n)
 		}
-		enumStr := fmt.Sprintf("[]int{%s}", strings.Join(strs, ", "))
+		enumStr := fmt.Sprintf("[]int64{%s}", strings.Join(strs, ", "))
 		o.L("Enum(%s).", enumStr)
 	}
 	if v.constantValue != nil {

--- a/validator/int_gen.go
+++ b/validator/int_gen.go
@@ -20,17 +20,17 @@ func compileIntegerValidator(s *schema.Schema, vocab *vocabulary.VocabularySet) 
 
 	if s.HasMultipleOf() && vocab.IsKeywordEnabled("multipleOf") {
 		rv := reflect.ValueOf(s.MultipleOf())
-		var tmp int
+		var tmp int64
 		switch rv.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			tmp = int(rv.Int())
+			tmp = int64(rv.Int())
 			b.MultipleOf(tmp)
 		case reflect.Float32, reflect.Float64:
 			f := rv.Float()
 			// Skip multipleOf constraint for very small values with integer type
 			// Any integer is a multiple of very small numbers like 1e-8
 			if f <= 0 || f >= 1 {
-				tmp = int(f)
+				tmp = int64(f)
 				b.MultipleOf(tmp)
 			}
 		default:
@@ -40,12 +40,12 @@ func compileIntegerValidator(s *schema.Schema, vocab *vocabulary.VocabularySet) 
 
 	if s.HasMaximum() && vocab.IsKeywordEnabled("maximum") {
 		rv := reflect.ValueOf(s.Maximum())
-		var tmp int
+		var tmp int64
 		switch rv.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			tmp = int(rv.Int())
+			tmp = int64(rv.Int())
 		case reflect.Float32, reflect.Float64:
-			tmp = int(rv.Float())
+			tmp = int64(rv.Float())
 		default:
 			return nil, fmt.Errorf(`invalid type for maximum field: expected numeric type, got %T`, rv.Interface())
 		}
@@ -54,12 +54,12 @@ func compileIntegerValidator(s *schema.Schema, vocab *vocabulary.VocabularySet) 
 
 	if s.HasExclusiveMaximum() && vocab.IsKeywordEnabled("exclusiveMaximum") {
 		rv := reflect.ValueOf(s.ExclusiveMaximum())
-		var tmp int
+		var tmp int64
 		switch rv.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			tmp = int(rv.Int())
+			tmp = int64(rv.Int())
 		case reflect.Float32, reflect.Float64:
-			tmp = int(rv.Float())
+			tmp = int64(rv.Float())
 		default:
 			return nil, fmt.Errorf(`invalid type for exclusiveMaximum field: expected numeric type, got %T`, rv.Interface())
 		}
@@ -68,12 +68,12 @@ func compileIntegerValidator(s *schema.Schema, vocab *vocabulary.VocabularySet) 
 
 	if s.HasMinimum() && vocab.IsKeywordEnabled("minimum") {
 		rv := reflect.ValueOf(s.Minimum())
-		var tmp int
+		var tmp int64
 		switch rv.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			tmp = int(rv.Int())
+			tmp = int64(rv.Int())
 		case reflect.Float32, reflect.Float64:
-			tmp = int(rv.Float())
+			tmp = int64(rv.Float())
 		default:
 			return nil, fmt.Errorf(`invalid type for minimum field: expected numeric type, got %T`, rv.Interface())
 		}
@@ -82,12 +82,12 @@ func compileIntegerValidator(s *schema.Schema, vocab *vocabulary.VocabularySet) 
 
 	if s.HasExclusiveMinimum() && vocab.IsKeywordEnabled("exclusiveMinimum") {
 		rv := reflect.ValueOf(s.ExclusiveMinimum())
-		var tmp int
+		var tmp int64
 		switch rv.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			tmp = int(rv.Int())
+			tmp = int64(rv.Int())
 		case reflect.Float32, reflect.Float64:
-			tmp = int(rv.Float())
+			tmp = int64(rv.Float())
 		default:
 			return nil, fmt.Errorf(`invalid type for exclusiveMinimum field: expected numeric type, got %T`, rv.Interface())
 		}
@@ -96,12 +96,12 @@ func compileIntegerValidator(s *schema.Schema, vocab *vocabulary.VocabularySet) 
 
 	if s.HasConst() && vocab.IsKeywordEnabled("const") {
 		rv := reflect.ValueOf(s.Const())
-		var tmp int
+		var tmp int64
 		switch rv.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			tmp = int(rv.Int())
+			tmp = int64(rv.Int())
 		case reflect.Float32, reflect.Float64:
-			tmp = int(rv.Float())
+			tmp = int64(rv.Float())
 		default:
 			return nil, fmt.Errorf(`invalid type for constantValue field: expected numeric type, got %T`, rv.Interface())
 		}
@@ -110,15 +110,15 @@ func compileIntegerValidator(s *schema.Schema, vocab *vocabulary.VocabularySet) 
 
 	if s.HasEnum() && vocab.IsKeywordEnabled("enum") {
 		enums := s.Enum()
-		l := make([]int, 0, len(enums))
+		l := make([]int64, 0, len(enums))
 		for i, e := range s.Enum() {
 			rv := reflect.ValueOf(e)
-			var tmp int
+			var tmp int64
 			switch rv.Kind() {
 			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-				tmp = int(rv.Int())
+				tmp = int64(rv.Int())
 			case reflect.Float32, reflect.Float64:
-				tmp = int(rv.Float())
+				tmp = int64(rv.Float())
 			default:
 				return nil, fmt.Errorf(`invalid element in enum: expected numeric element, got %T for element %d`, e, i)
 			}
@@ -130,13 +130,13 @@ func compileIntegerValidator(s *schema.Schema, vocab *vocabulary.VocabularySet) 
 }
 
 type integerValidator struct {
-	multipleOf       *int
-	maximum          *int
-	exclusiveMaximum *int
-	minimum          *int
-	exclusiveMinimum *int
-	constantValue    *int
-	enum             []int
+	multipleOf       *int64
+	maximum          *int64
+	exclusiveMaximum *int64
+	minimum          *int64
+	exclusiveMinimum *int64
+	constantValue    *int64
+	enum             []int64
 }
 
 type IntegerValidatorBuilder struct {
@@ -148,7 +148,7 @@ func Integer() *IntegerValidatorBuilder {
 	return (&IntegerValidatorBuilder{}).Reset()
 }
 
-func (b *IntegerValidatorBuilder) MultipleOf(v int) *IntegerValidatorBuilder {
+func (b *IntegerValidatorBuilder) MultipleOf(v int64) *IntegerValidatorBuilder {
 	if b.err != nil {
 		return b
 	}
@@ -156,7 +156,7 @@ func (b *IntegerValidatorBuilder) MultipleOf(v int) *IntegerValidatorBuilder {
 	return b
 }
 
-func (b *IntegerValidatorBuilder) Maximum(v int) *IntegerValidatorBuilder {
+func (b *IntegerValidatorBuilder) Maximum(v int64) *IntegerValidatorBuilder {
 	if b.err != nil {
 		return b
 	}
@@ -164,7 +164,7 @@ func (b *IntegerValidatorBuilder) Maximum(v int) *IntegerValidatorBuilder {
 	return b
 }
 
-func (b *IntegerValidatorBuilder) ExclusiveMaximum(v int) *IntegerValidatorBuilder {
+func (b *IntegerValidatorBuilder) ExclusiveMaximum(v int64) *IntegerValidatorBuilder {
 	if b.err != nil {
 		return b
 	}
@@ -172,7 +172,7 @@ func (b *IntegerValidatorBuilder) ExclusiveMaximum(v int) *IntegerValidatorBuild
 	return b
 }
 
-func (b *IntegerValidatorBuilder) Minimum(v int) *IntegerValidatorBuilder {
+func (b *IntegerValidatorBuilder) Minimum(v int64) *IntegerValidatorBuilder {
 	if b.err != nil {
 		return b
 	}
@@ -180,7 +180,7 @@ func (b *IntegerValidatorBuilder) Minimum(v int) *IntegerValidatorBuilder {
 	return b
 }
 
-func (b *IntegerValidatorBuilder) ExclusiveMinimum(v int) *IntegerValidatorBuilder {
+func (b *IntegerValidatorBuilder) ExclusiveMinimum(v int64) *IntegerValidatorBuilder {
 	if b.err != nil {
 		return b
 	}
@@ -188,7 +188,7 @@ func (b *IntegerValidatorBuilder) ExclusiveMinimum(v int) *IntegerValidatorBuild
 	return b
 }
 
-func (b *IntegerValidatorBuilder) Const(v int) *IntegerValidatorBuilder {
+func (b *IntegerValidatorBuilder) Const(v int64) *IntegerValidatorBuilder {
 	if b.err != nil {
 		return b
 	}
@@ -196,11 +196,11 @@ func (b *IntegerValidatorBuilder) Const(v int) *IntegerValidatorBuilder {
 	return b
 }
 
-func (b *IntegerValidatorBuilder) Enum(v ...int) *IntegerValidatorBuilder {
+func (b *IntegerValidatorBuilder) Enum(v ...int64) *IntegerValidatorBuilder {
 	if b.err != nil {
 		return b
 	}
-	b.c.enum = make([]int, len(v))
+	b.c.enum = make([]int64, len(v))
 	copy(b.c.enum, v)
 	return b
 }
@@ -226,22 +226,15 @@ func (b *IntegerValidatorBuilder) Reset() *IntegerValidatorBuilder {
 }
 
 func (v *integerValidator) Validate(_ context.Context, in any, _ ...ValidateOption) (Result, error) {
-	rv := reflect.ValueOf(in)
-
-	var n int
-	switch rv.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		n = int(rv.Int())
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		n = int(rv.Uint())
-	case reflect.Float32, reflect.Float64:
-		f := rv.Float()
-		if f != float64(int(f)) {
-			return nil, fmt.Errorf(`expected integer, got float value %g`, f)
-		}
-		n = int(f)
-	default:
+	n, ok, isInt, err := numericInt(in)
+	if err != nil {
+		return nil, fmt.Errorf(`invalid value passed to IntegerValidator: %w`, err)
+	}
+	if !ok {
 		return nil, fmt.Errorf(`invalid value passed to IntegerValidator: expected integer, got %T`, in)
+	}
+	if !isInt {
+		return nil, fmt.Errorf(`invalid value passed to IntegerValidator: expected integer, got non-integer value %v`, in)
 	}
 
 	if m := v.maximum; m != nil {

--- a/validator/internal/cmd/gennumeric/main.go
+++ b/validator/internal/cmd/gennumeric/main.go
@@ -32,7 +32,7 @@ func main() {
 func _main(outputDir string) error {
 	defs := []definition{
 		{
-			typ:      "int",
+			typ:      "int64",
 			class:    "Integer",
 			filename: "int_gen.go",
 		},
@@ -101,14 +101,14 @@ func generateValidator(def definition, outputDir string) error {
 			o.L("var tmp %s", def.typ)
 			o.L("switch rv.Kind() {")
 			o.L("case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:")
-			if def.typ == "int" {
-				o.L("tmp = int(rv.Int())")
+			if def.class == "Integer" {
+				o.L("tmp = %s(rv.Int())", def.typ)
 			} else {
 				o.L("tmp = float64(rv.Int())")
 			}
 			o.L("case reflect.Float32, reflect.Float64:")
-			if def.typ == "int" {
-				o.L("tmp = int(rv.Float())")
+			if def.class == "Integer" {
+				o.L("tmp = %s(rv.Float())", def.typ)
 			} else {
 				o.L("tmp = rv.Float()")
 			}
@@ -128,8 +128,8 @@ func generateValidator(def definition, outputDir string) error {
 			o.L("var tmp %s", def.typ)
 			o.L("switch rv.Kind() {")
 			o.L("case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:")
-			if def.typ == "int" {
-				o.L("tmp = int(rv.Int())")
+			if def.class == "Integer" {
+				o.L("tmp = %s(rv.Int())", def.typ)
 			} else {
 				o.L("tmp = float64(rv.Int())")
 			}
@@ -137,26 +137,26 @@ func generateValidator(def definition, outputDir string) error {
 				o.L("b.%s(tmp)", methodName)
 			}
 			o.L("case reflect.Float32, reflect.Float64:")
-			if def.typ == "int" {
+			if def.class == "Integer" {
 				if prop == "multipleOf" {
 					o.L("f := rv.Float()")
 					o.L("// Skip multipleOf constraint for very small values with integer type")
 					o.L("// Any integer is a multiple of very small numbers like 1e-8")
 					o.L("if f <= 0 || f >= 1 {")
-					o.L("tmp = int(f)")
+					o.L("tmp = %s(f)", def.typ)
 					o.L("b.%s(tmp)", methodName)
 					o.L("}")
 				} else {
-					o.L("tmp = int(rv.Float())")
+					o.L("tmp = %s(rv.Float())", def.typ)
 				}
 			} else {
 				o.L("tmp = rv.Float()")
 			}
-			if def.typ != "int" || prop != "multipleOf" {
+			if def.class != "Integer" || prop != "multipleOf" {
 				o.L("default:")
 				o.L("return nil, fmt.Errorf(`invalid type for %s field: expected numeric type, got %%T`, rv.Interface())", prop)
 				o.L("}") // switch
-				if def.typ != "int" || prop != "multipleOf" {
+				if def.class != "Integer" || prop != "multipleOf" {
 					o.L("b.%s(tmp)", methodName)
 				}
 			} else {
@@ -238,39 +238,33 @@ func generateValidator(def definition, outputDir string) error {
 	o.L("}")
 
 	var template string
-	if def.typ == "int" {
+	if def.class == "Integer" {
 		template = "d"
 	} else {
 		template = "f"
 	}
 	o.LL("func (v *%sValidator) Validate(_ context.Context, in any, _ ...ValidateOption) (Result, error) {", xstrings.Snake(def.class))
-	o.L("rv := reflect.ValueOf(in)")
-	if def.typ == "int" {
-		o.LL("var n int")
-		o.L("switch rv.Kind() {")
-		o.L("case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:")
-		o.L("n = int(rv.Int())")
-		o.L("case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:")
-		o.L("n = int(rv.Uint())")
-		o.L("case reflect.Float32, reflect.Float64:")
-		o.L("f := rv.Float()")
-		o.L("if f != float64(int(f)) {")
-		o.L("return nil, fmt.Errorf(`expected integer, got float value %%g`, f)")
+	if def.class == "Integer" {
+		// numericInt accepts native numeric kinds and json.Number (UseNumber),
+		// preserving int64 precision. isInt distinguishes a non-integer number
+		// (e.g. 5.5) from a genuine integer; err flags an integer outside int64.
+		o.L("n, ok, isInt, err := numericInt(in)")
+		o.L("if err != nil {")
+		o.L("return nil, fmt.Errorf(`invalid value passed to IntegerValidator: %%w`, err)")
 		o.L("}")
-		o.L("n = int(f)")
-		o.L("default:")
+		o.L("if !ok {")
 		o.L("return nil, fmt.Errorf(`invalid value passed to IntegerValidator: expected integer, got %%T`, in)")
 		o.L("}")
+		o.L("if !isInt {")
+		o.L("return nil, fmt.Errorf(`invalid value passed to IntegerValidator: expected integer, got non-integer value %%v`, in)")
+		o.L("}")
 	} else {
-		o.LL("var n float64")
-		o.L("switch rv.Kind() {")
-		o.L("case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:")
-		o.L("n = float64(rv.Int())")
-		o.L("case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:")
-		o.L("n = float64(rv.Uint())")
-		o.L("case reflect.Float32, reflect.Float64:")
-		o.L("n = rv.Float()")
-		o.L("default:")
+		// numericFloat accepts native numeric kinds and json.Number (UseNumber).
+		o.L("n, ok, err := numericFloat(in)")
+		o.L("if err != nil {")
+		o.L("return nil, fmt.Errorf(`invalid value passed to NumberValidator: %%w`, err)")
+		o.L("}")
+		o.L("if !ok {")
 		o.L("return nil, fmt.Errorf(`invalid value passed to NumberValidator: expected number, got %%T`, in)")
 		o.L("}")
 		o.L("")
@@ -300,7 +294,7 @@ func generateValidator(def definition, outputDir string) error {
 	o.L("}")
 	o.L("}")
 	o.LL("if mo := v.multipleOf; mo != nil {")
-	if def.typ == "int" {
+	if def.class == "Integer" {
 		o.L("if *mo == 0 {")
 		o.L("return nil, fmt.Errorf(`invalid value passed to IntegerValidator: multipleOf cannot be zero`)")
 		o.L("}")

--- a/validator/json.go
+++ b/validator/json.go
@@ -1,0 +1,47 @@
+package validator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// ValidateJSON validates raw JSON text against an already-compiled validator,
+// saving callers the boilerplate of unmarshaling first. Compile a schema once
+// with Compile, then call ValidateJSON per input (the compile-once /
+// validate-many pattern).
+//
+// Numbers are decoded as json.Number to preserve precision: an integer in the
+// 2^53..2^63 range survives intact rather than being rounded by float64, so it
+// can be validated exactly against integer constraints. (Integer values outside
+// the int64 range cannot be validated as integers and are reported as an error.)
+//
+// The input must contain exactly one top-level JSON value; trailing content
+// after it (other than whitespace) is rejected.
+func ValidateJSON(ctx context.Context, v Interface, data []byte, options ...ValidateOption) (Result, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+
+	var decoded any
+	if err := dec.Decode(&decoded); err != nil {
+		if err == io.EOF {
+			return nil, fmt.Errorf("failed to decode JSON: empty input")
+		}
+		return nil, fmt.Errorf("failed to decode JSON: %w", err)
+	}
+
+	// Reject trailing content after the first value. Everything from the
+	// decoder's current offset onward must be JSON whitespace. This avoids a
+	// second Decode pass (and its allocation) just to detect trailing data.
+	for _, b := range data[dec.InputOffset():] {
+		switch b {
+		case ' ', '\t', '\n', '\r':
+		default:
+			return nil, fmt.Errorf("invalid JSON: trailing data after top-level value")
+		}
+	}
+
+	return v.Validate(ctx, decoded, options...)
+}

--- a/validator/json_bench_test.go
+++ b/validator/json_bench_test.go
@@ -1,0 +1,80 @@
+package validator_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+)
+
+// benchData is a representative object with nested structure and numbers,
+// exercising both the object/array traversal and the numeric validators.
+var benchData = []byte(`{
+	"id": 9007199254740993,
+	"role": "admin",
+	"score": 87.5,
+	"tags": ["a", "b", "c"],
+	"profile": {"age": 42, "active": true}
+}`)
+
+func benchSchema() *schema.Schema {
+	return schema.NewBuilder().
+		Types(schema.ObjectType).
+		Property("id", schema.NewBuilder().Types(schema.IntegerType).MustBuild()).
+		Property("role", schema.Enum("admin", "user").MustBuild()).
+		Property("score", schema.NewBuilder().Types(schema.NumberType).MustBuild()).
+		Property("tags", schema.NewBuilder().
+			Types(schema.ArrayType).
+			Items(schema.NewBuilder().Types(schema.StringType).MustBuild()).
+			MustBuild()).
+		Property("profile", schema.NewBuilder().
+			Types(schema.ObjectType).
+			Property("age", schema.NewBuilder().Types(schema.IntegerType).MustBuild()).
+			Property("active", schema.NewBuilder().Types(schema.BooleanType).MustBuild()).
+			MustBuild()).
+		Required("id", "role").
+		MustBuild()
+}
+
+// BenchmarkValidate_UnmarshalThenValidate measures the "decode to a Go object
+// first" path: json.Unmarshal into any, then Validate. The unmarshal is inside
+// the loop because it is part of the cost being compared.
+func BenchmarkValidate_UnmarshalThenValidate(b *testing.B) {
+	ctx := context.Background()
+	v, err := validator.Compile(ctx, benchSchema())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var decoded any
+		if err := json.Unmarshal(benchData, &decoded); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := v.Validate(ctx, decoded); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkValidate_ValidateJSON measures the direct raw-bytes path
+// (UseNumber decode + validate) via ValidateJSON.
+func BenchmarkValidate_ValidateJSON(b *testing.B) {
+	ctx := context.Background()
+	v, err := validator.Compile(ctx, benchSchema())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := validator.ValidateJSON(ctx, v, benchData); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/validator/json_test.go
+++ b/validator/json_test.go
@@ -1,0 +1,120 @@
+package validator_test
+
+import (
+	"testing"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateJSON(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("malformed and empty input", func(t *testing.T) {
+		s := schema.NewBuilder().Types(schema.ObjectType).MustBuild()
+		v, err := validator.Compile(ctx, s)
+		require.NoError(t, err)
+
+		testCases := []struct {
+			name string
+			data string
+		}{
+			{name: "empty", data: ""},
+			{name: "whitespace only", data: "   \n\t "},
+			{name: "invalid json", data: `{"a":}`},
+			{name: "trailing value", data: `{} {}`},
+			{name: "trailing scalar", data: `5 6`},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := validator.ValidateJSON(ctx, v, []byte(tc.data))
+				require.Error(t, err)
+			})
+		}
+	})
+
+	t.Run("object", func(t *testing.T) {
+		s := schema.NewBuilder().
+			Types(schema.ObjectType).
+			Property("id", schema.PositiveInteger().MustBuild()).
+			Property("role", schema.Enum("admin", "user").MustBuild()).
+			Required("id", "role").
+			MustBuild()
+		v, err := validator.Compile(ctx, s)
+		require.NoError(t, err)
+
+		_, err = validator.ValidateJSON(ctx, v, []byte(`{"id": 1, "role": "admin"}`))
+		require.NoError(t, err)
+
+		_, err = validator.ValidateJSON(ctx, v, []byte(`{"id": 1, "role": "root"}`))
+		require.Error(t, err)
+
+		_, err = validator.ValidateJSON(ctx, v, []byte(`{"role": "admin"}`))
+		require.Error(t, err, "missing required id")
+
+		// Surrounding whitespace is fine.
+		_, err = validator.ValidateJSON(ctx, v, []byte("\n  {\"id\": 1, \"role\": \"user\"}\n"))
+		require.NoError(t, err)
+	})
+
+	t.Run("integer precision and form", func(t *testing.T) {
+		s := schema.NewBuilder().Types(schema.IntegerType).MustBuild()
+		v, err := validator.Compile(ctx, s)
+		require.NoError(t, err)
+
+		testCases := []struct {
+			name    string
+			data    string
+			wantErr bool
+		}{
+			{name: "large integer beyond 2^53", data: "9007199254740993"},
+			{name: "integral with decimal point", data: "5.0"},
+			{name: "exponent form integer", data: "1e2"},
+			{name: "fractional fails", data: "5.5", wantErr: true},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := validator.ValidateJSON(ctx, v, []byte(tc.data))
+				if tc.wantErr {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("const and enum", func(t *testing.T) {
+		constSchema := schema.NewBuilder().Const(42).MustBuild()
+		cv, err := validator.Compile(ctx, constSchema)
+		require.NoError(t, err)
+		_, err = validator.ValidateJSON(ctx, cv, []byte("42"))
+		require.NoError(t, err)
+		_, err = validator.ValidateJSON(ctx, cv, []byte("43"))
+		require.Error(t, err)
+
+		enumSchema := schema.NewBuilder().Enum(1, 2, 3).MustBuild()
+		ev, err := validator.Compile(ctx, enumSchema)
+		require.NoError(t, err)
+		_, err = validator.ValidateJSON(ctx, ev, []byte("2"))
+		require.NoError(t, err)
+		_, err = validator.ValidateJSON(ctx, ev, []byte("9"))
+		require.Error(t, err)
+	})
+
+	t.Run("multi-type integer or string", func(t *testing.T) {
+		s := schema.NewBuilder().Types(schema.IntegerType, schema.StringType).MustBuild()
+		v, err := validator.Compile(ctx, s)
+		require.NoError(t, err)
+
+		_, err = validator.ValidateJSON(ctx, v, []byte("5"))
+		require.NoError(t, err, "integer satisfies the integer branch")
+
+		_, err = validator.ValidateJSON(ctx, v, []byte(`"hello"`))
+		require.NoError(t, err, "string satisfies the string branch")
+
+		_, err = validator.ValidateJSON(ctx, v, []byte("true"))
+		require.Error(t, err, "boolean satisfies neither branch")
+	})
+}

--- a/validator/number_gen.go
+++ b/validator/number_gen.go
@@ -221,17 +221,11 @@ func (b *NumberValidatorBuilder) Reset() *NumberValidatorBuilder {
 }
 
 func (v *numberValidator) Validate(_ context.Context, in any, _ ...ValidateOption) (Result, error) {
-	rv := reflect.ValueOf(in)
-
-	var n float64
-	switch rv.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		n = float64(rv.Int())
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		n = float64(rv.Uint())
-	case reflect.Float32, reflect.Float64:
-		n = rv.Float()
-	default:
+	n, ok, err := numericFloat(in)
+	if err != nil {
+		return nil, fmt.Errorf(`invalid value passed to NumberValidator: %w`, err)
+	}
+	if !ok {
 		return nil, fmt.Errorf(`invalid value passed to NumberValidator: expected number, got %T`, in)
 	}
 

--- a/validator/numeric.go
+++ b/validator/numeric.go
@@ -1,0 +1,125 @@
+package validator
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+)
+
+// The helpers in this file are the single place that decides whether an
+// incoming value is a JSON number and what its value is. They accept BOTH
+// native Go numeric kinds (int*, uint*, float*) — as produced by json.Unmarshal,
+// struct fields, or builder-supplied literals — AND json.Number, as produced by
+// a decoder configured with UseNumber (see ValidateJSON). json.Number is a named
+// string type, so reflect.ValueOf(json.Number("1")).Kind() reports
+// reflect.String; every numeric site must therefore consult these helpers rather
+// than switching on reflect.Kind directly, and the string validator must exclude
+// json.Number (see isJSONNumber).
+
+// isNumeric reports whether v is a JSON number value: any native Go numeric kind
+// OR a json.Number. A plain string is never considered numeric.
+func isNumeric(v any) bool {
+	if _, ok := v.(json.Number); ok {
+		return true
+	}
+	switch reflect.ValueOf(v).Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
+}
+
+// isJSONNumber reports whether v is specifically a json.Number. The string
+// validator uses this to exclude numbers that would otherwise report
+// reflect.String kind and be validated as strings.
+func isJSONNumber(v any) bool {
+	_, ok := v.(json.Number)
+	return ok
+}
+
+// numericFloat converts a numeric value (native kind or json.Number) to float64.
+// ok is false when v is not numeric at all. err is non-nil only when v is a
+// json.Number whose text cannot be parsed as a float (it should not happen for
+// decoder output, but is surfaced rather than silently swallowed).
+func numericFloat(v any) (float64, bool, error) {
+	if n, ok := v.(json.Number); ok {
+		f, err := n.Float64()
+		if err != nil {
+			return 0, true, err
+		}
+		return f, true, nil
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return float64(rv.Int()), true, nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return float64(rv.Uint()), true, nil
+	case reflect.Float32, reflect.Float64:
+		return rv.Float(), true, nil
+	default:
+		return 0, false, nil
+	}
+}
+
+// numericInt converts a numeric value to an int64, preserving precision for
+// json.Number via Int64() (so integers in the 2^53..2^63 range that float64
+// would round are exact). The three return signals are:
+//   - ok=false:              v is not numeric at all (caller reports a type error)
+//   - ok=true, isInt=false:  numeric but not an integer (e.g. 5.5); n is unset
+//   - ok=true, isInt=true:   n holds the integer value
+//
+// A non-nil err means v is an integer-valued number outside the int64 range
+// (±9.2e18); such values cannot be validated as integers and are reported
+// rather than silently truncated.
+func numericInt(v any) (int64, bool, bool, error) {
+	if num, ok := v.(json.Number); ok {
+		if i, err := num.Int64(); err == nil {
+			return i, true, true, nil
+		}
+		// Int64 rejects exponent forms (e.g. "1e2") and out-of-range values.
+		// Fall back to Float64 to tell an integral value apart from a fractional
+		// one, and from one that simply does not fit in int64.
+		f, err := num.Float64()
+		if err != nil {
+			return 0, true, false, err
+		}
+		return integralFloatToInt64(f, num.String())
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return rv.Int(), true, true, nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		u := rv.Uint()
+		if u > math.MaxInt64 {
+			return 0, true, false, fmt.Errorf("integer value %d out of int64 range", u)
+		}
+		return int64(u), true, true, nil
+	case reflect.Float32, reflect.Float64:
+		return integralFloatToInt64(rv.Float(), "")
+	default:
+		return 0, false, false, nil
+	}
+}
+
+// integralFloatToInt64 reports whether f is an integer value and, if so, returns
+// it as int64. text, when non-empty, is the original json.Number text used for a
+// precise out-of-range error message.
+func integralFloatToInt64(f float64, text string) (int64, bool, bool, error) {
+	if f != math.Trunc(f) {
+		return 0, true, false, nil // fractional: numeric but not an integer
+	}
+	// float64(math.MaxInt64) rounds up to 2^63, so the upper bound is exclusive.
+	if f < math.MinInt64 || f >= math.MaxInt64 {
+		if text == "" {
+			return 0, true, false, fmt.Errorf("integer value %v out of int64 range", f)
+		}
+		return 0, true, false, fmt.Errorf("integer value %s out of int64 range", text)
+	}
+	return int64(f), true, true, nil
+}

--- a/validator/numeric_test.go
+++ b/validator/numeric_test.go
@@ -1,0 +1,151 @@
+package validator
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNumericHelpers(t *testing.T) {
+	t.Run("isNumeric", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			in   any
+			want bool
+		}{
+			{name: "int", in: 5, want: true},
+			{name: "int64", in: int64(5), want: true},
+			{name: "uint64", in: uint64(5), want: true},
+			{name: "float64", in: 5.5, want: true},
+			{name: "json.Number int", in: json.Number("5"), want: true},
+			{name: "json.Number float", in: json.Number("5.5"), want: true},
+			{name: "string", in: "5", want: false},
+			{name: "bool", in: true, want: false},
+			{name: "nil", in: nil, want: false},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				require.Equal(t, tc.want, isNumeric(tc.in))
+			})
+		}
+	})
+
+	t.Run("isJSONNumber", func(t *testing.T) {
+		require.True(t, isJSONNumber(json.Number("5")))
+		require.False(t, isJSONNumber("5"))
+		require.False(t, isJSONNumber(5))
+		require.False(t, isJSONNumber(nil))
+	})
+
+	t.Run("numericFloat", func(t *testing.T) {
+		testCases := []struct {
+			name    string
+			in      any
+			want    float64
+			wantOK  bool
+			wantErr bool
+		}{
+			{name: "int", in: 5, want: 5, wantOK: true},
+			{name: "float64", in: 5.5, want: 5.5, wantOK: true},
+			{name: "uint64", in: uint64(7), want: 7, wantOK: true},
+			{name: "json.Number int", in: json.Number("5"), want: 5, wantOK: true},
+			{name: "json.Number float", in: json.Number("5.5"), want: 5.5, wantOK: true},
+			{name: "json.Number exponent", in: json.Number("1e2"), want: 100, wantOK: true},
+			{name: "string", in: "5", wantOK: false},
+			{name: "nil", in: nil, wantOK: false},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				got, ok, err := numericFloat(tc.in)
+				if tc.wantErr {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, tc.wantOK, ok)
+				if tc.wantOK {
+					require.Equal(t, tc.want, got)
+				}
+			})
+		}
+	})
+
+	t.Run("numericInt", func(t *testing.T) {
+		testCases := []struct {
+			name      string
+			in        any
+			want      int64
+			wantOK    bool
+			wantIsInt bool
+			wantErr   bool
+		}{
+			{name: "int", in: 5, want: 5, wantOK: true, wantIsInt: true},
+			{name: "int64", in: int64(5), want: 5, wantOK: true, wantIsInt: true},
+			{name: "uint64", in: uint64(5), want: 5, wantOK: true, wantIsInt: true},
+			{name: "negative", in: -3, want: -3, wantOK: true, wantIsInt: true},
+			{name: "float integral", in: 5.0, want: 5, wantOK: true, wantIsInt: true},
+			{name: "float fractional", in: 5.5, wantOK: true, wantIsInt: false},
+			{name: "json.Number int", in: json.Number("5"), want: 5, wantOK: true, wantIsInt: true},
+			{name: "json.Number 5.0", in: json.Number("5.0"), want: 5, wantOK: true, wantIsInt: true},
+			{name: "json.Number 5.5", in: json.Number("5.5"), wantOK: true, wantIsInt: false},
+			{name: "json.Number exponent", in: json.Number("1e2"), want: 100, wantOK: true, wantIsInt: true},
+			{name: "json.Number negative", in: json.Number("-3"), want: -3, wantOK: true, wantIsInt: true},
+			{name: "json.Number beyond 2^53", in: json.Number("9007199254740993"), want: 9007199254740993, wantOK: true, wantIsInt: true},
+			{name: "json.Number out of int64 range", in: json.Number("99999999999999999999"), wantOK: true, wantErr: true},
+			{name: "uint64 out of int64 range", in: uint64(math.MaxUint64), wantOK: true, wantErr: true},
+			{name: "string", in: "5", wantOK: false},
+			{name: "bool", in: true, wantOK: false},
+			{name: "nil", in: nil, wantOK: false},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				got, ok, isInt, err := numericInt(tc.in)
+				if tc.wantErr {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, tc.wantOK, ok)
+				require.Equal(t, tc.wantIsInt, isInt)
+				if tc.wantIsInt {
+					require.Equal(t, tc.want, got)
+				}
+			})
+		}
+	})
+}
+
+// TestNumericValidatorsAcceptJSONNumber confirms the typed numeric validators
+// treat a json.Number identically to the equivalent native value.
+func TestNumericValidatorsAcceptJSONNumber(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("integer accepts json.Number integer", func(t *testing.T) {
+		v := Integer().Minimum(0).Maximum(10).MustBuild()
+		_, err := v.Validate(ctx, json.Number("5"))
+		require.NoError(t, err)
+	})
+	t.Run("integer rejects fractional json.Number", func(t *testing.T) {
+		v := Integer().MustBuild()
+		_, err := v.Validate(ctx, json.Number("5.5"))
+		require.Error(t, err)
+	})
+	t.Run("integer accepts integral 5.0 json.Number", func(t *testing.T) {
+		v := Integer().MustBuild()
+		_, err := v.Validate(ctx, json.Number("5.0"))
+		require.NoError(t, err)
+	})
+	t.Run("number accepts json.Number float", func(t *testing.T) {
+		v := Number().Minimum(0).MustBuild()
+		_, err := v.Validate(ctx, json.Number("5.5"))
+		require.NoError(t, err)
+	})
+	t.Run("string rejects json.Number under strict type", func(t *testing.T) {
+		// strictStringType is set when a schema explicitly declares type: string.
+		v := &stringValidator{strictStringType: true}
+		_, err := v.Validate(ctx, json.Number("5"))
+		require.Error(t, err)
+	})
+}

--- a/validator/object.go
+++ b/validator/object.go
@@ -292,6 +292,13 @@ func (b *ObjectValidatorBuilder) Reset() *ObjectValidatorBuilder {
 // instances (using the JSON tag's name, ignoring options like ",omitempty").
 // The bool reports whether v is object-like at all.
 func extractObjectProperties(v any) (map[string]any, bool, error) {
+	// Fast path for the standard JSON-decoded shape: return the map directly
+	// instead of reflectively rebuilding it. Callers treat the result as
+	// read-only, so sharing the caller's map is safe.
+	if m, ok := v.(map[string]any); ok {
+		return m, true, nil
+	}
+
 	if resolver, ok := v.(ObjectFieldResolver); ok {
 		props := make(map[string]any)
 		for _, name := range resolver.FieldNames() {

--- a/validator/resolver_wiring_test.go
+++ b/validator/resolver_wiring_test.go
@@ -57,6 +57,47 @@ func TestObjectFieldResolverDrivesValidation(t *testing.T) {
 	})
 }
 
+// TestUnevaluatedPropertiesThroughResolver covers the unevaluatedProperties
+// keyword for object values that are not map[string]any. Previously the
+// unevaluated coordinator only accepted map[string]any, so it skipped (or, under
+// strict object type, wrongly rejected) ObjectFieldResolver and struct values.
+// It now reuses extractObjectProperties, matching the object validator and
+// dependentSchemas.
+func TestUnevaluatedPropertiesThroughResolver(t *testing.T) {
+	s, err := schema.NewBuilder().
+		Types(schema.ObjectType).
+		Property("name", schema.NewBuilder().Types(schema.StringType).MustBuild()).
+		UnevaluatedProperties(schema.FalseSchema()).
+		Build()
+	require.NoError(t, err)
+	v, err := validator.Compile(t.Context(), s)
+	require.NoError(t, err)
+
+	t.Run("resolver: evaluated-only object passes", func(t *testing.T) {
+		_, err := v.Validate(t.Context(), opaqueObject{store: map[string]any{"name": "ok"}})
+		require.NoError(t, err)
+	})
+
+	t.Run("resolver: unevaluated property rejected", func(t *testing.T) {
+		_, err := v.Validate(t.Context(), opaqueObject{store: map[string]any{"name": "ok", "extra": 1}})
+		require.Error(t, err, "extra is unevaluated and unevaluatedProperties:false")
+	})
+
+	t.Run("map sanity: unevaluated property rejected", func(t *testing.T) {
+		_, err := v.Validate(t.Context(), map[string]any{"name": "ok", "extra": 1})
+		require.Error(t, err)
+	})
+
+	t.Run("struct: unevaluated field rejected", func(t *testing.T) {
+		type person struct {
+			Name string `json:"name"`
+			Age  int    `json:"age"`
+		}
+		_, err := v.Validate(t.Context(), person{Name: "ok", Age: 1})
+		require.Error(t, err, "age is unevaluated and unevaluatedProperties:false")
+	})
+}
+
 // opaqueArray is reachable only through the ArrayIndexResolver interface,
 // demonstrating that Len() lets length-based keywords (minItems/maxItems) and
 // per-item keywords (prefixItems/items) work through the resolver.

--- a/validator/string.go
+++ b/validator/string.go
@@ -39,8 +39,11 @@ func (v *stringValidator) Validate(ctx context.Context, in any, _ ...ValidateOpt
 	logger.InfoContext(ctx, "string validator starting", "value", in, "type", fmt.Sprintf("%T", in))
 	rv := reflect.ValueOf(in)
 
-	switch rv.Kind() {
-	case reflect.String:
+	// json.Number is a named string type, so its reflect.Kind is String. Exclude
+	// it explicitly so a JSON number decoded with UseNumber is not mistaken for a
+	// string (see validator/numeric.go).
+	switch {
+	case rv.Kind() == reflect.String && !isJSONNumber(in):
 		logger.InfoContext(ctx, "string validator processing string value")
 		// Continue with string validation
 	default:

--- a/validator/unevaluated_coordinator.go
+++ b/validator/unevaluated_coordinator.go
@@ -254,13 +254,14 @@ func (v *unevaluatedCoordinator) handleUnevaluatedItem(ctx context.Context, inde
 // Helper functions for type resolution
 
 func resolveToObjectMap(in any) (map[string]any, bool) {
-	switch obj := in.(type) {
-	case map[string]any:
-		return obj, true
-	default:
-		// Could add more object types here if needed
+	// Reuse the object validator's extraction so map[string]any takes the fast
+	// path and structs / ObjectFieldResolvers are handled identically to the
+	// object validator and dependentSchemas (rather than only map[string]any).
+	props, ok, err := extractObjectProperties(in)
+	if err != nil || !ok {
 		return nil, false
 	}
+	return props, true
 }
 
 func resolveToArray(in any) (reflect.Value, int, bool) {

--- a/validator/untyped.go
+++ b/validator/untyped.go
@@ -148,34 +148,13 @@ func jsonSchemaEqual(a, b any) bool {
 	return false
 }
 
-// convertToNumber converts a value to float64 if it's a numeric type
+// convertToNumber converts a value to float64 if it's a numeric type. It
+// recognizes native numeric kinds and json.Number (see validator/numeric.go),
+// so enum/const equality treats 5, 5.0, and json.Number("5") as equal.
 func convertToNumber(v any) (float64, bool) {
-	switch val := v.(type) {
-	case int:
-		return float64(val), true
-	case int8:
-		return float64(val), true
-	case int16:
-		return float64(val), true
-	case int32:
-		return float64(val), true
-	case int64:
-		return float64(val), true
-	case uint:
-		return float64(val), true
-	case uint8:
-		return float64(val), true
-	case uint16:
-		return float64(val), true
-	case uint32:
-		return float64(val), true
-	case uint64:
-		return float64(val), true
-	case float32:
-		return float64(val), true
-	case float64:
-		return val, true
-	default:
+	f, ok, err := numericFloat(v)
+	if err != nil || !ok {
 		return 0, false
 	}
+	return f, true
 }

--- a/validator/validators.go
+++ b/validator/validators.go
@@ -3,7 +3,6 @@ package validator
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	schema "github.com/lestrrat-go/json-schema"
 	"github.com/lestrrat-go/json-schema/vocabulary"
@@ -28,19 +27,14 @@ func compileInferredNumberValidator(s *schema.Schema, vocab *vocabulary.Vocabula
 }
 
 func (v *inferredNumberValidator) Validate(ctx context.Context, in any, _ ...ValidateOption) (Result, error) {
-	// Check if the value is numeric
-	rv := reflect.ValueOf(in)
-	switch rv.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
-		reflect.Float32, reflect.Float64:
-		// Value is numeric, apply number validation
+	// isNumeric recognizes native numeric kinds and json.Number (see
+	// validator/numeric.go); non-numeric values ignore numeric constraints per
+	// the JSON Schema spec.
+	if isNumeric(in) {
 		return v.numberValidator.Validate(ctx, in)
-	default:
-		// Value is not numeric, ignore numeric constraints (per JSON Schema spec)
-		//nolint: nilnil
-		return nil, nil
 	}
+	//nolint: nilnil
+	return nil, nil
 }
 
 type EmptyValidator struct{}


### PR DESCRIPTION
- add `validator.ValidateJSON(ctx, v, data)`: raw-JSON validation, `UseNumber` decode (large-integer precision), rejects empty/trailing input
- widen integer validator to `int64`; teach the engine to accept `json.Number` (centralized in `numeric.go`)
- reflection-free fast path in `extractObjectProperties`/`newArrayAccessor` for `map[string]any`/`[]any` (speeds up all `Validate`, ~20% / fewer allocs); apply `unevaluatedProperties` to structs and `ObjectFieldResolver` values
