### PR TITLE
add fuzzing infrastructure and workflow

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,62 @@
+name: Fuzz
+# Runs Go native fuzzing in two modes from a single workflow:
+#   - pull_request: a short smoke run on every PR to catch easy regressions fast.
+#   - schedule / workflow_dispatch: a longer run that actually explores the corpus.
+# FUZZTIME is selected per-event below.
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 3 * * 3' # Weekly on Wednesday at 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      fuzz-time:
+        description: 'Duration per fuzz target (e.g. 30s, 5m, 10m)'
+        required: false
+        default: '5m'
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: schema
+            path: .
+          - name: validator
+            path: ./validator
+    name: "Fuzz ${{ matrix.name }}"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Go stable version
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          check-latest: true
+          cache: false
+      - name: Restore fuzz cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/go-build/fuzz
+          key: fuzz-${{ matrix.name }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-${{ matrix.name }}-
+      - name: Run fuzz tests
+        env:
+          # PRs get a quick smoke run; scheduled/dispatch runs explore for longer.
+          FUZZTIME: ${{ github.event_name == 'pull_request' && '30s' || github.event.inputs.fuzz-time || '5m' }}
+        run: ./fuzz.sh ${{ matrix.path }}
+      - name: Upload failing corpus
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-corpus-${{ matrix.name }}
+          path: '**/testdata/fuzz/**'
+          if-no-files-found: ignore
+          retention-days: 30

--- a/fuzz.sh
+++ b/fuzz.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Run Go native fuzz targets for a single package.
+#
+# Usage:
+#   ./fuzz.sh <package>      # e.g. ./fuzz.sh .   or   ./fuzz.sh ./validator
+#
+# Every Fuzz* target discovered in the package is exercised in turn. Duration per
+# target is controlled by the FUZZTIME environment variable (default 5m); CI passes
+# a short value on pull requests for a smoke run and the full value on schedule.
+#
+# This script cd's to its own directory so it can be invoked from anywhere.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+pkg="${1:-}"
+if [[ -z "$pkg" ]]; then
+	echo "usage: $0 <package>   (e.g. . or ./validator)" >&2
+	exit 2
+fi
+
+fuzztime="${FUZZTIME:-5m}"
+
+# Discover fuzz targets in the package. `-list` prints matching identifiers plus a
+# trailing package-result line; grep keeps only the Fuzz* names.
+targets="$(go test "$pkg" -list '^Fuzz' -run '^$' | grep '^Fuzz' || true)"
+
+if [[ -z "$targets" ]]; then
+	echo "no fuzz targets found in $pkg"
+	exit 0
+fi
+
+status=0
+for target in $targets; do
+	echo "==> fuzzing ${target} in ${pkg} (fuzztime=${fuzztime})"
+	if ! go test "$pkg" -run '^$' -fuzz "^${target}\$" -fuzztime "$fuzztime"; then
+		status=1
+	fi
+done
+
+exit "$status"

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,51 @@
+package schema_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	schema "github.com/lestrrat-go/json-schema"
+)
+
+// FuzzUnmarshalSchema feeds arbitrary bytes to Schema unmarshaling and, for any
+// input that parses cleanly, marshals it back. The contract under test is "never
+// panic": malformed input must surface as an error, and a schema that round-trips
+// through MarshalJSON must not crash.
+func FuzzUnmarshalSchema(f *testing.F) {
+	f.Add([]byte(`true`))
+	f.Add([]byte(`false`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"type":"object","properties":{"id":{"type":"integer"}},"required":["id"]}`))
+	f.Add([]byte(`{"type":["string","null"]}`))
+	f.Add([]byte(`{"$ref":"#/$defs/foo","$defs":{"foo":{"type":"string"}}}`))
+	f.Add([]byte(`{"allOf":[{"minimum":0},{"maximum":10}]}`))
+	f.Add([]byte(``))
+	f.Add([]byte(`not-json`))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		var s schema.Schema
+		if err := json.Unmarshal(data, &s); err != nil {
+			return
+		}
+		// A schema that unmarshaled successfully must be re-marshalable without panicking.
+		_, _ = json.Marshal(&s)
+	})
+}
+
+// FuzzPrimitiveTypes targets PrimitiveTypes.UnmarshalJSON directly. It accepts a
+// single type string or an array of them; the goal is to ensure no input — empty,
+// scalar, or malformed — panics (see the empty-input panic fixed in #47).
+func FuzzPrimitiveTypes(f *testing.F) {
+	f.Add([]byte(`"string"`))
+	f.Add([]byte(`["string","null"]`))
+	f.Add([]byte(`[]`))
+	f.Add([]byte(``))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`123`))
+	f.Add([]byte(`["string",123]`))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		var pt schema.PrimitiveTypes
+		_ = json.Unmarshal(data, &pt)
+	})
+}

--- a/validator/fuzz_test.go
+++ b/validator/fuzz_test.go
@@ -1,0 +1,55 @@
+package validator_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	schema "github.com/lestrrat-go/json-schema"
+	"github.com/lestrrat-go/json-schema/validator"
+)
+
+// FuzzCompile feeds arbitrary bytes through the full unmarshal -> Compile path. Any
+// schema that parses must compile without panicking; a compile error is acceptable
+// (e.g. an unresolvable $ref), a panic is not.
+func FuzzCompile(f *testing.F) {
+	f.Add([]byte(`true`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"type":"object","properties":{"id":{"type":"integer"}}}`))
+	f.Add([]byte(`{"type":["string","null"],"minLength":1}`))
+	f.Add([]byte(`{"allOf":[{"minimum":0},{"maximum":10}]}`))
+	f.Add([]byte(`{"$ref":"#/$defs/foo","$defs":{"foo":{"type":"string"}}}`))
+	f.Add([]byte(`{"pattern":"^a.*z$"}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var s schema.Schema
+		if err := json.Unmarshal(data, &s); err != nil {
+			return
+		}
+		_, _ = validator.Compile(t.Context(), &s)
+	})
+}
+
+// FuzzValidateJSON fuzzes both halves of the pipeline at once: an arbitrary schema is
+// compiled, then arbitrary data is validated against it. Neither Compile nor
+// ValidateJSON may panic regardless of how malformed either input is.
+func FuzzValidateJSON(f *testing.F) {
+	f.Add([]byte(`{"type":"object","required":["id"]}`), []byte(`{"id":1}`))
+	f.Add([]byte(`{"type":"integer","minimum":0}`), []byte(`42`))
+	f.Add([]byte(`{"type":"string","pattern":"^x"}`), []byte(`"xyz"`))
+	f.Add([]byte(`{"enum":["a","b"]}`), []byte(`"c"`))
+	f.Add([]byte(`true`), []byte(``))
+	f.Add([]byte(`{}`), []byte(`{"anything":true}`))
+
+	f.Fuzz(func(t *testing.T, schemaData, valueData []byte) {
+		var s schema.Schema
+		if err := json.Unmarshal(schemaData, &s); err != nil {
+			return
+		}
+		v, err := validator.Compile(t.Context(), &s)
+		if err != nil {
+			return
+		}
+		// Validation may pass or fail; we only require that it never panics.
+		_, _ = validator.ValidateJSON(t.Context(), v, valueData)
+	})
+}


### PR DESCRIPTION
- Add Go-native fuzz targets: `FuzzUnmarshalSchema`/`FuzzPrimitiveTypes` (root) and `FuzzCompile`/`FuzzValidateJSON` (validator)
- Add `fuzz.sh` runner that auto-discovers `Fuzz*` targets per package, duration via `FUZZTIME`
- Add `Fuzz` workflow: 30s smoke run on every PR, weekly + manual full runs, uploads crashers on failure
